### PR TITLE
Add einsum function in the linear_algebra examples

### DIFF
--- a/array.h
+++ b/array.h
@@ -235,15 +235,11 @@ class interval {
 
   /** Two interval objects are considered equal if they contain the
    * same indices. */
-  template <index_t OtherMin, index_t OtherExtent,
-      class = internal::enable_if_compatible<Min, OtherMin>,
-      class = internal::enable_if_compatible<Extent, OtherExtent>>
+  template <index_t OtherMin, index_t OtherExtent>
   bool operator==(const interval<OtherMin, OtherExtent>& other) const {
     return min() == other.min() && extent() == other.extent();
   }
-  template <index_t OtherMin, index_t OtherExtent,
-      class = internal::enable_if_compatible<Min, OtherMin>,
-      class = internal::enable_if_compatible<Extent, OtherExtent>>
+  template <index_t OtherMin, index_t OtherExtent>
   bool operator!=(const interval<OtherMin, OtherExtent>& other) const {
     return !operator==(other);
   }
@@ -385,17 +381,11 @@ class dim : private interval<Min_, Extent_> {
 
   /** Two dim objects are considered equal if their mins, extents, and strides
    * are equal. */
-  template <index_t OtherMin, index_t OtherExtent, index_t OtherStride,
-      class = internal::enable_if_compatible<Min, OtherMin>,
-      class = internal::enable_if_compatible<Extent, OtherExtent>,
-      class = internal::enable_if_compatible<Stride, OtherStride>>
+  template <index_t OtherMin, index_t OtherExtent, index_t OtherStride>
   bool operator==(const dim<OtherMin, OtherExtent, OtherStride>& other) const {
     return min() == other.min() && extent() == other.extent() && stride() == other.stride();
   }
-  template <index_t OtherMin, index_t OtherExtent, index_t OtherStride,
-      class = internal::enable_if_compatible<Min, OtherMin>,
-      class = internal::enable_if_compatible<Extent, OtherExtent>,
-      class = internal::enable_if_compatible<Stride, OtherStride>>
+  template <index_t OtherMin, index_t OtherExtent, index_t OtherStride>
   bool operator!=(const dim<OtherMin, OtherExtent, OtherStride>& other) const {
     return !operator==(other);
   }

--- a/array.h
+++ b/array.h
@@ -532,10 +532,11 @@ NDARRAY_INLINE constexpr index_t sum(index_t first, Rest... rest) {
   return first + sum(rest...);
 }
 
-NDARRAY_INLINE constexpr index_t product() { return 1; }
-template <class... Rest>
-NDARRAY_INLINE constexpr index_t product(index_t first, Rest... rest) {
-  return first * product(rest...);
+template <class T>
+NDARRAY_INLINE constexpr T product() { return 1; }
+template <class T, class... Rest>
+NDARRAY_INLINE constexpr T product(T first, Rest... rest) {
+  return first * product<T>(rest...);
 }
 
 NDARRAY_INLINE constexpr index_t variadic_min() { return std::numeric_limits<index_t>::max(); }
@@ -553,7 +554,7 @@ NDARRAY_INLINE constexpr index_t variadic_max(index_t first, Rest... rest) {
 // Computes the product of the extents of the dims.
 template <class Tuple, size_t... Is>
 index_t product(const Tuple& t, index_sequence<Is...>) {
-  return product(std::get<Is>(t)...);
+  return product<index_t>(std::get<Is>(t)...);
 }
 
 // Returns true if all of bools are true.

--- a/array.h
+++ b/array.h
@@ -2753,13 +2753,13 @@ class auto_allocator {
     allocated = false;
   }
 
-  template <class U, size_t U_N>
-  friend bool operator==(const auto_allocator<T, N>& a, const auto_allocator<U, U_N>& b) {
+  template <class U, size_t U_N, size_t U_A>
+  friend bool operator==(const auto_allocator& a, const auto_allocator<U, U_N, U_A>& b) {
     return &a.buffer[0] == &b.buffer[0];
   }
 
-  template <class U, size_t U_N>
-  friend bool operator!=(const auto_allocator<T, N>& a, const auto_allocator<U, U_N>& b) {
+  template <class U, size_t U_N, size_t U_A>
+  friend bool operator!=(const auto_allocator& a, const auto_allocator<U, U_N, U_A>& b) {
     return &a.buffer[0] != &b.buffer[0];
   }
 };
@@ -2800,6 +2800,17 @@ class uninitialized_allocator : public BaseAlloc {
     if (sizeof...(Args) > 0) {
       std::allocator_traits<BaseAlloc>::construct(*this, ptr, std::forward<Args>(args)...);
     }
+  }
+
+  template <class OtherBaseAlloc>
+  friend bool operator==(
+      const uninitialized_allocator& a, const uninitialized_allocator<OtherBaseAlloc>& b) {
+    return static_cast<const BaseAlloc&>(a) == static_cast<const OtherBaseAlloc&>(b);
+  }
+  template <class OtherBaseAlloc>
+  friend bool operator!=(
+      const uninitialized_allocator& a, const uninitialized_allocator<OtherBaseAlloc>& b) {
+    return static_cast<const BaseAlloc&>(a) != static_cast<const OtherBaseAlloc&>(b);
   }
 };
 

--- a/examples/linear_algebra/Makefile
+++ b/examples/linear_algebra/Makefile
@@ -2,9 +2,9 @@ CFLAGS := $(CFLAGS) -O2 -ffast-math -fstrict-aliasing -march=native
 CXXFLAGS := $(CXXFLAGS) -std=c++14 -Wall
 LDFLAGS := $(LDFLAGS)
 
-ARRAY_DEPS := ../../array.h ../../matrix.h ../benchmark.h
+DEPS := ../../array.h ../../matrix.h ../benchmark.h einsum.h
 
-bin/%: %.cpp $(ARRAY_DEPS)
+bin/%: %.cpp $(DEPS)
 	mkdir -p $(@D)
 	$(CXX) -I../../ -I../ -o $@ $< $(CFLAGS) $(CXXFLAGS) -lstdc++ -lm
 

--- a/examples/linear_algebra/Makefile
+++ b/examples/linear_algebra/Makefile
@@ -13,7 +13,8 @@ bin/%: %.cpp $(ARRAY_DEPS)
 clean:
 	rm -rf obj/* bin/*
 
-test: bin/matrix bin/conv2d bin/conv3d
+test: bin/matrix bin/conv2d bin/conv3d bin/einsum
 	bin/matrix
 	bin/conv2d
 	bin/conv3d
+	bin/einsum

--- a/examples/linear_algebra/Makefile
+++ b/examples/linear_algebra/Makefile
@@ -13,8 +13,8 @@ bin/%: %.cpp $(DEPS)
 clean:
 	rm -rf obj/* bin/*
 
-test: bin/matrix bin/conv2d bin/conv3d bin/einsum
+test: bin/einsum bin/matrix bin/conv2d bin/conv3d
+	bin/einsum
 	bin/matrix
 	bin/conv2d
 	bin/conv3d
-	bin/einsum

--- a/examples/linear_algebra/einsum.cpp
+++ b/examples/linear_algebra/einsum.cpp
@@ -27,6 +27,7 @@ int main(int, const char**) {
   constexpr index_t M = 12;
   constexpr index_t N = 8;
 
+  array_of_rank<float, 3> T({4, 5, 8});
   matrix<float, N, N> A;
   matrix<float, M, N> B;
   vector<float, N> x;
@@ -88,6 +89,20 @@ int main(int, const char**) {
       Bx_i += B(i, j) * x(j);
     }
     assert(relative_error(Bx(i), Bx_i) < tolerance);
+  }
+
+  // sum(T)
+  float sumT = make_einsum<float>(ein<i, j, k>(T))();
+  float sumT_ref = 0.0f;
+  T.for_each_value([&](float i) { sumT_ref += i; });
+  assert(relative_error(sumT, sumT_ref) < tolerance);
+
+  // sum of the i and k dims of T
+  auto sum_ik = make_einsum<float, j>(ein<i, j, k>(T));
+  for (index_t j : T.j()) {
+    float sum_ik_ref = 0.0f;
+    T(_, j, _).for_each_value([&](float i) { sum_ik_ref += i; });
+    assert(relative_error(sum_ik(j), sum_ik_ref) < tolerance);
   }
 
   return 0;

--- a/examples/linear_algebra/einsum.cpp
+++ b/examples/linear_algebra/einsum.cpp
@@ -14,16 +14,10 @@
 
 #include "matrix.h"
 #include "einsum.h"
-#include "benchmark.h"
 
 #include <random>
-#include <iostream>
 
 using namespace nda;
-
-enum { i = 0, j = 1, k = 2 };
-
-const float tolerance = 1e-4f;
 
 float relative_error(float a, float b) {
   return std::abs(a - b) / std::max(a, b);
@@ -39,6 +33,9 @@ int main(int, const char**) {
   vector<float, N> y;
   vector<float, M> z;
 
+  // Helpful names for dimensions we use in einsums.
+  enum { i = 0, j = 1, k = 2 };
+
   // `generate` assigns each element of the array with the
   // result of the generating function. Use this to fill the
   // arrays with random data.
@@ -48,6 +45,8 @@ int main(int, const char**) {
   generate(B, [&]() { return uniform(rng); });
   generate(x, [&]() { return uniform(rng); });
   generate(y, [&]() { return uniform(rng); });
+
+  const float tolerance = 1e-6f;
 
   // trace(a)
   float tr = make_einsum<float>(ein<i, i>(A))();

--- a/examples/linear_algebra/einsum.cpp
+++ b/examples/linear_algebra/einsum.cpp
@@ -83,6 +83,7 @@ int main(int, const char**) {
 
   // B*x
   auto Bx = make_einsum<float, i>(ein<i, j>(B), ein<j>(x));
+  assert(Bx.size() == B.rows());
   for (index_t i : Bx.i()) {
     float Bx_i = 0.0f;
     for (index_t j : x.i()) {

--- a/examples/linear_algebra/einsum.cpp
+++ b/examples/linear_algebra/einsum.cpp
@@ -1,0 +1,86 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "matrix.h"
+#include "einsum.h"
+#include "benchmark.h"
+
+#include <random>
+#include <iostream>
+
+using namespace nda;
+
+enum { i = 0, j = 1, k = 2 };
+
+const float tolerance = 1e-4f;
+
+float relative_error(float a, float b) {
+  return std::abs(a - b) / std::max(a, b);
+}
+
+int main(int, const char**) {
+  constexpr index_t M = 12;
+  constexpr index_t N = 8;
+
+  matrix<float, N, N> a;
+  matrix<float, M, N> b;
+  vector<float, N> x;
+  vector<float, N> y;
+  vector<float, M> z;
+
+  // `generate` assigns each element of the array with the
+  // result of the generating function. Use this to fill the
+  // arrays with random data.
+  std::mt19937_64 rng;
+  std::uniform_real_distribution<float> uniform(0, 1);
+  generate(a, [&]() { return uniform(rng); });
+  generate(b, [&]() { return uniform(rng); });
+  generate(x, [&]() { return uniform(rng); });
+  generate(y, [&]() { return uniform(rng); });
+
+  // trace(a)
+  float tr = make_einsum<float>(ein<i, i>(a))();
+  float tr_ref = 0.0f;
+  for (index_t i : a.i()) {
+    tr_ref += a(i, i);
+  }
+  assert(relative_error(tr, tr_ref) < tolerance);
+
+  // diag(a)
+  auto a_diag = make_einsum<float, i>(ein<i, i>(a));
+  for (index_t i : a.i()) {
+    assert(a_diag(i) == a(i, i));
+  }
+
+  // dot(x, y)
+  float dot = make_einsum<float>(ein<i>(x), ein<i>(y))();
+  float dot_ref = 0.0f;
+  for (index_t i : a.i()) {
+    dot_ref += x(i) * y(i);
+  }
+  assert(relative_error(dot, dot_ref) < tolerance);
+
+  // x^T*z
+  auto outer = make_einsum<float, i, j>(ein<i>(x), ein<j>(z));
+  assert(outer.rows() == x.size());
+  assert(outer.columns() == z.size());
+  for (index_t i : outer.i()) {
+    for (index_t j : outer.j()) {
+      assert(outer(i, j) == x(i) * z(j));
+    }
+  }
+
+  return 0;
+}
+

--- a/examples/linear_algebra/einsum.cpp
+++ b/examples/linear_algebra/einsum.cpp
@@ -73,6 +73,14 @@ int main(int, const char**) {
   }
   assert(relative_error(dot, dot_ref) < tolerance);
 
+  // dot(x.*x, y.*y)
+  float dot_sq = make_einsum<float>(ein<i>(x), ein<i>(x), ein<i>(y), ein<i>(y))();
+  float dot_sq_ref = 0.0f;
+  for (index_t i : A.i()) {
+    dot_sq_ref += x(i) * x(i) * y(i) * y(i);
+  }
+  assert(relative_error(dot_sq, dot_sq_ref) < tolerance);
+
   // x^T*z
   auto outer = make_einsum<float, i, j>(ein<i>(x), ein<j>(z));
   assert(outer.rank() == 2);

--- a/examples/linear_algebra/einsum.cpp
+++ b/examples/linear_algebra/einsum.cpp
@@ -23,9 +23,11 @@ float relative_error(float a, float b) {
   return std::abs(a - b) / std::max(a, b);
 }
 
+// Examples/tests of einsum. With clang -O2, many of these generate
+// zero overhead implementations.
 int main(int, const char**) {
-  constexpr index_t M = 12;
-  constexpr index_t N = 8;
+  constexpr index_t M = 50;
+  constexpr index_t N = 64;
 
   array_of_rank<float, 3> T({4, 5, 8});
   matrix<float, N, N> A;

--- a/examples/linear_algebra/einsum.cpp
+++ b/examples/linear_algebra/einsum.cpp
@@ -37,13 +37,13 @@ template <class... Ts>
 constexpr index_t product(index_t a, Ts... b) { return a * product(b...); }
 
 // Defines the arbitrary rank Levi-Civita tensor as a constexpr function.
-constexpr float epsilon() {
-  return 1.0f;
-}
-template <class T0, class... Ts>
-constexpr float epsilon(T0 i0, Ts... is) {
+constexpr float epsilon() { return 1.0f; }
+template <class... Ts>
+constexpr float epsilon(index_t i0, Ts... is) {
   return product(sgn(is - i0)...) * epsilon(is...);
 }
+
+constexpr float epsilon3(index_t i, index_t j, index_t k) { return epsilon(i, j, k); }
 
 // Examples/tests of einsum. With clang -O2, many of these generate
 // zero overhead implementations.
@@ -113,7 +113,6 @@ int main(int, const char**) {
 
   // TODO: We can't infer the output shape of this, because ein<> of a function
   // doesn't provide a shape.
-  auto epsilon3 = epsilon<int, int, int>;
   vector<float, 3> cross({}, 0.0f);
   einsum(ein<i, j, k>(epsilon3), ein<j>(x3), ein<k>(y3), ein<i>(cross));
   assert(cross.rank() == 1);

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -192,6 +192,8 @@ auto ein(const array<T, Shape, Alloc>& op) {
  * - `x`, `y`, `Ax` are vectors (rank 1 arrays)
  * - `tr_A`, `dot_xy` are scalar (rank 0 arrays)
  **/
+// The only reason we can't just variadic argument this like einsum_impl
+// is to have the result be the last argument :(
 template <class Op0, class Result>
 void einsum(const Op0& op0, const Result& result) {
   internal::einsum_impl(result, op0);
@@ -244,6 +246,8 @@ auto make_einsum_impl(const Alloc& alloc, const Ops&... ops) {
  * - `A`, `B` are matrices (rank 2 arrays)
  * - `x`, `y` are vectors (rank 1 arrays)
  **/
+// The only reason we can't just variadic argument this like make_einsum_impl
+// is to have the result be the last argument :(
 // TODO: Add an overload with a default ResultIs... = 0, 1, 2, ... This requires
 // also inferring the rank of the result.
 template <class T, size_t... ResultIs, class Op0, class Alloc = std::allocator<T>,

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -171,7 +171,9 @@ auto ein(const array<T, Shape, Alloc>& op) {
  * function, which describes which dimensions of the summation index
  * should be used to address that argument.
  *
- * The result of the summation is added to the result.
+ * The result of the summation is added to `result`. `result` must be
+ * initialized to some useful value (typically 0) before calling this
+ * function.
  *
  * Examples:
  * - `einsum(ein<0, 0>(A), ein<>(tr_A))`, the trace of A.

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -166,7 +166,7 @@ auto ein(const array<T, Shape, Alloc>& op) {
  * notation. See https://en.wikipedia.org/wiki/Einstein_notation for more
  * information about the notation itself.
  *
- * This function accepts a list of arguments arg1, arg2, ... result.
+ * This function accepts a list of arguments arg0, arg1, ... result.
  * Each argument is the result of the `ein<i, j, ...>(arg)` helper
  * function, which describes which dimensions of the summation index
  * should be used to address that argument.
@@ -185,24 +185,22 @@ auto ein(const array<T, Shape, Alloc>& op) {
  * - `tr_A`, `dot_xy` are scalar (rank 0 arrays)
  **/
 template <
-    class Arg1, size_t... Arg1Is, class Arg2, size_t... Arg2Is, class ResultArg, size_t... ResultIs>
+    class Arg0, size_t... Arg0Is, class Arg1, size_t... Arg1Is, class ResultArg, size_t... ResultIs>
 void einsum(
+    const internal::einsum_arg<Arg0, Arg0Is...>& arg0,
     const internal::einsum_arg<Arg1, Arg1Is...>& arg1,
-    const internal::einsum_arg<Arg2, Arg2Is...>& arg2,
     const internal::einsum_arg<ResultArg, ResultIs...>& result) {
-  constexpr size_t LoopRank = internal::variadic_max(Arg1Is..., Arg2Is..., ResultIs...) + 1;
+  constexpr size_t LoopRank = internal::variadic_max(Arg0Is..., Arg1Is..., ResultIs...) + 1;
 
-  internal::einsum_impl<LoopRank>(result, arg1, arg2);
+  internal::einsum_impl<LoopRank>(result, arg0, arg1);
 }
-template <
-    size_t... Arg1Is, size_t... ResultIs,
-    class Arg1, class ResultArg>
+template <size_t... Arg0Is, size_t... ResultIs, class Arg0, class ResultArg>
 void einsum(
-    const internal::einsum_arg<Arg1, Arg1Is...>& arg1,
+    const internal::einsum_arg<Arg0, Arg0Is...>& arg0,
     const internal::einsum_arg<ResultArg, ResultIs...>& result) {
-  constexpr size_t LoopRank = internal::variadic_max(Arg1Is..., ResultIs...) + 1;
+  constexpr size_t LoopRank = internal::variadic_max(Arg0Is..., ResultIs...) + 1;
 
-  internal::einsum_impl<LoopRank>(result, arg1);
+  internal::einsum_impl<LoopRank>(result, arg0);
 }
 // TODO: Consider supporting einsum of more than 2 operands.
 

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -46,12 +46,12 @@ auto reductions(const std::tuple<Dims...>& dims) {
 
 template <class Dim0, class... Dims>
 auto reconcile_dim(const Dim0& dim0, const Dims&... dims) {
-  // If all dims are broadcasts, the intervals should match.
+  // If all dims are broadcasts, the intervals should match (the strides are
+  // zero and must match).
   // TODO: Maybe we should always assert the intervals should match.
   // this would catch some kinds of errors in einsum expressions, but
   // it will also require some expressions to include explicit cropping.
-  assert(any(dim0.stride() != 0, (dims.stride() != 0)...) ||
-         all(dim0.min() == dims.min() && dim0.extent() == dims.extent()...));
+  assert(any(dim0.stride() != 0, (dims.stride() != 0)...) || all(dim0 == dims...));
   // dims... will be accessed with dim0's bounds, so check this is possible.
   assert(all(dims.is_in_range(dim0)...));
   return dim0;

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -247,7 +247,7 @@ auto make_einsum_impl(const Alloc& alloc, const Ops&... ops) {
  * - `x`, `y` are vectors (rank 1 arrays)
  **/
 // The only reason we can't just variadic argument this like make_einsum_impl
-// is to have the result be the last argument :(
+// is to have the allocator be the last argument :(
 // TODO: Add an overload with a default ResultIs... = 0, 1, 2, ... This requires
 // also inferring the rank of the result.
 template <class T, size_t... ResultIs, class Op0, class Alloc = std::allocator<T>,
@@ -276,4 +276,4 @@ auto make_einsum(
 
 }  // namespace nda
 
-#endif  // NDARRAY_IMAGE_H
+#endif  // NDARRAY_EINSUM_H

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -95,9 +95,7 @@ auto ein_shape(const einsum_op<array_ref<T, Shape>, Is...>& ein) {
   return std::get<0>(ein).shape();
 }
 template <class T, size_t... Is>
-auto ein_shape(const einsum_op<T, Is...>& ein) {
-  return shape<>();
-}
+auto ein_shape(const einsum_op<T, Is...>& ein) { return shape<>(); }
 
 template <class T>
 NDARRAY_INLINE T product() { return static_cast<T>(1); }
@@ -189,8 +187,7 @@ auto ein(const array<T, Shape, Alloc>& op) {
  * Einstein summation. Because this operand does not provide a shape,
  * the dimensions of the sum must be inferred from other operands.
  * See `einsum` for more details. */
-template <size_t... Is, class Fn,
-    class = internal::enable_if_callable<Fn, decltype(Is)...>>
+template <size_t... Is, class Fn, class = internal::enable_if_callable<Fn, decltype(Is)...>>
 auto ein(Fn&& fn) {
   return std::make_tuple(fn, internal::index_sequence<Is...>());
 }

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -144,15 +144,18 @@ auto infer_einsum_result_shape(const Args&... args) {
  * a set of dimension indices. `ein<i, j, ...>(a)` means the dimensions
  * `i, j, ...` of the summation index are used to address `a` during
  * Einstein summation. See `einsum` for more details. */
-template <size_t... Is, class T, class Shape>
+template <size_t... Is, class T, class Shape,
+    class = std::enable_if_t<sizeof...(Is) == Shape::rank()>>
 auto ein(const array_ref<T, Shape>& op) {
   return std::make_tuple(op, std::index_sequence<Is...>());
 }
-template <size_t... Is, class T, class Shape, class Alloc>
+template <size_t... Is, class T, class Shape, class Alloc,
+    class = std::enable_if_t<sizeof...(Is) == Shape::rank()>>
 auto ein(array<T, Shape, Alloc>& op) {
   return ein<Is...>(op.ref());
 }
-template <size_t... Is, class T, class Shape, class Alloc>
+template <size_t... Is, class T, class Shape, class Alloc,
+    class = std::enable_if_t<sizeof...(Is) == Shape::rank()>>
 auto ein(const array<T, Shape, Alloc>& op) {
   return ein<Is...>(op.cref());
 }
@@ -188,6 +191,7 @@ void einsum(
 template <class T, size_t... ResultIs, class... Args>
 auto make_einsum(const Args&... args) {
   auto result_shape = internal::infer_einsum_result_shape<ResultIs...>(args...);
+  // TODO: use make_array<T>(shape, 0) when overload ambiguity is fixed.
   auto result = make_array<T>(make_compact(result_shape));
   einsum(args..., ein<ResultIs...>(result));
   return result;

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -25,7 +25,7 @@ template <class Arg, size_t... Is>
 using einsum_arg = std::tuple<Arg, std::index_sequence<Is...>>;
 template <size_t... Is, class Arg>
 einsum_arg<Arg, Is...> ein(const Arg& op) {
-  return {op, std::index_sequence<Is...>()};
+  return std::make_tuple(op, std::index_sequence<Is...>());
 }
 
 namespace internal {

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -86,6 +86,11 @@ auto gather_dims(std::index_sequence<Is...>, const Dims&... dims) {
   return std::make_tuple(gather_dim<Is>(dims...)...);
 }
 
+template <class Idx, class Arg, size_t... Is>
+auto ein_at(const einsum_arg<Arg, Is...>& ein, const Idx& i) {
+  return std::get<0>(ein)(std::get<Is>(i)...);
+}
+
 }  // namespace internal
 
 template <
@@ -117,11 +122,8 @@ void einsum(
   // Reinterpret the result as having a shape of the reduction dimensions.
   auto reduction = reinterpret_shape(std::get<0>(result), reduction_shape);
 
-  auto op1 = std::get<0>(arg1);
-  auto op2 = std::get<0>(arg2);
-
   for_each_index(reduction_shape, [&](const index_of_rank<LoopRank>& i) {
-    reduction(i) += op1(std::get<Arg1Is>(i)...) * op2(std::get<Arg2Is>(i)...);
+    reduction(i) += internal::ein_at(arg1, i) * internal::ein_at(arg2, i);
   });
 }
 

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/** \file image.h
- * \brief Optional image-specific helpers and specializations.
-*/
 #ifndef NDARRAY_EINSUM_H
 #define NDARRAY_EINSUM_H
 
@@ -22,9 +19,10 @@
 
 namespace nda {
 
+/** Argument for an Einstein summation, which is an array along with
+ * a set of dimension indices. */
 template <class Arg, size_t... Is>
 using einsum_arg = std::tuple<Arg, std::index_sequence<Is...>>;
-
 template <size_t... Is, class Arg>
 einsum_arg<Arg, Is...> ein(const Arg& op) {
   return {op, std::index_sequence<Is...>()};
@@ -113,6 +111,8 @@ void einsum(
       std::make_tuple(result_dims, std::get<1>(result)),
       std::make_tuple(arg1_dims, std::get<1>(arg1)),
       std::make_tuple(arg2_dims, std::get<1>(arg2))));
+
+  // TODO: Try to compile-time optimize reduction_shape :)
 
   // Reinterpret the result as having a shape of the reduction dimensions.
   auto reduction = reinterpret_shape(std::get<0>(result), reduction_shape);

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -46,8 +46,10 @@ auto reductions(const std::tuple<Dims...>& dims) {
   return reductions(dims, std::make_index_sequence<sizeof...(Dims)>());
 }
 
-// If a dim appears other than twice in gather_dims, the summation is ill-formed.
+// If a dim appears more than twice in gather_dims, the summation is ill-formed.
 // TODO: Not sure about that...
+template <class Dim1>
+auto reconcile_dim(const Dim1& dim1) { return dim1; }
 template <class Dim1, class Dim2>
 auto reconcile_dim(const Dim1& dim1, const Dim2& dim2) {
   assert(dim1.min() == dim2.min());

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -97,11 +97,6 @@ auto ein_shape(const einsum_op<array_ref<T, Shape>, Is...>& ein) {
 template <class T, size_t... Is>
 auto ein_shape(const einsum_op<T, Is...>& ein) { return shape<>(); }
 
-template <class T>
-NDARRAY_INLINE T product() { return static_cast<T>(1); }
-template <class T, class... Ts>
-NDARRAY_INLINE T product(T a, Ts... b) { return a * product<T>(b...); }
-
 // Get the max index of an index_sequence.
 template <size_t... Is>
 constexpr size_t max(index_sequence<Is...>) {
@@ -181,12 +176,12 @@ auto ein(const array<T, Shape, Alloc>& op) {
   return ein<Is...>(op.cref());
 }
 
-/** Define an Einstein summation operand with a function instead of
- * an array or array_ref. `ein<i, j, ...>(fn)` means the dimensions
- * `i, j, ...` of the summation index are used to call `fn` during
- * Einstein summation. Because this operand does not provide a shape,
- * the dimensions of the sum must be inferred from other operands.
- * See `einsum` for more details. */
+/** Define an Einstein summation operand with a callable object
+ * instead of an array or array_ref. `ein<i, j, ...>(fn)` means the
+ * dimensions `i, j, ...` of the summation index are used to call
+ * `fn` during Einstein summation. Because this operand does not
+ * provide a shape, the dimensions of the sum must be inferred from
+ * other operands. See `einsum` for more details. */
 template <size_t... Is, class Fn, class = internal::enable_if_callable<Fn, decltype(Is)...>>
 auto ein(Fn&& fn) {
   return std::make_tuple(fn, internal::index_sequence<Is...>());

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -147,7 +147,7 @@ auto infer_einsum_result_shape(const Ops&... ops) {
 
 }  // namespace internal
 
-/** Opument for an Einstein summation, which is an array along with
+/** Operand for an Einstein summation, which is an array along with
  * a set of dimension indices. `ein<i, j, ...>(a)` means the dimensions
  * `i, j, ...` of the summation index are used to address `a` during
  * Einstein summation. See `einsum` for more details. */
@@ -174,7 +174,7 @@ auto ein(const array<T, Shape, Alloc>& op) {
  *
  * This function accepts a list of operands op0, ..., result. Each operand
  * is the result of the `ein<i, j, ...>(op)` helper function, which
- * describes which dimensions of the summation index  should be used to
+ * describes which dimensions of the summation index should be used to
  * address that operand.
  *
  * The result of the summation is added to `result`. `result` must be

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -1,0 +1,131 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** \file image.h
+ * \brief Optional image-specific helpers and specializations.
+*/
+#ifndef NDARRAY_EINSUM_H
+#define NDARRAY_EINSUM_H
+
+#include "array.h"
+
+namespace nda {
+
+template <class Arg, size_t... Is>
+using einsum_arg = std::tuple<Arg, std::index_sequence<Is...>>;
+
+template <size_t... Is, class Arg>
+einsum_arg<Arg, Is...> ein(const Arg& op) {
+  return {op, std::index_sequence<Is...>()};
+}
+
+namespace internal {
+
+// Make a dimension a reduction dimension (give it a constexpr stride 0).
+template <index_t Min, index_t Extent, index_t Stride>
+auto reduction(const dim<Min, Extent, Stride>& d) {
+  return dim<Min, Extent, 0>(d.min(), d.extent());
+}
+
+// Make all of the dimensions reduction dimensions.
+template <class... Dims, size_t... Is>
+auto reductions(const std::tuple<Dims...>& dims, std::index_sequence<Is...>) {
+  return std::make_tuple(reduction(std::get<Is>(dims))...);
+}
+template <class... Dims>
+auto reductions(const std::tuple<Dims...>& dims) {
+  return reductions(dims, std::make_index_sequence<sizeof...(Dims)>());
+}
+
+// Given a list of dimensions, assert they have all equal min and extent,
+// and return the first.
+template <class Dim>
+auto reconcile_dim(const Dim& dim) {
+  return dim;
+}
+template <class Dim1, class... Dims>
+auto reconcile_dim(const Dim1& dim1, const Dims&... dims) {
+  assert(all(dim1.min() == dims.min()...));
+  assert(all(dim1.max() == dims.max()...));
+  return dim1;
+}
+
+template <class... Dims, size_t... Is>
+auto reconcile_dim(const std::tuple<Dims...>& dims, std::index_sequence<Is...>) {
+  return reconcile_dim(std::get<Is>(dims)...);
+}
+template <class... Dims>
+auto reconcile_dim(const std::tuple<Dims...>& dims) {
+  return reconcile_dim(dims, std::make_index_sequence<sizeof...(Dims)>());
+}
+
+// Gather all of the dimensions for einsum arguments into one shape.
+template <
+    size_t Dim, size_t... Arg1Is, size_t... Arg2Is, size_t... Arg3Is,
+    class Dims1, class Dims2, class Dims3>
+auto gather_dim(
+    const einsum_arg<Dims1, Arg1Is...>& arg1,
+    const einsum_arg<Dims2, Arg2Is...>& arg2,
+    const einsum_arg<Dims3, Arg3Is...>& arg3) {
+  return reconcile_dim(std::tuple_cat(
+      get_tuple<index_of<Dim, Arg1Is...>()>(std::get<0>(arg1)),
+      get_tuple<index_of<Dim, Arg2Is...>()>(std::get<0>(arg2)),
+      get_tuple<index_of<Dim, Arg3Is...>()>(std::get<0>(arg3))));
+}
+template <class... Dims, size_t... Is>
+auto gather_dims(std::index_sequence<Is...>, const Dims&... dims) {
+  return std::make_tuple(gather_dim<Is>(dims...)...);
+}
+
+}  // namespace internal
+
+template <
+    size_t... Arg1Is, size_t... Arg2Is, size_t... ResultIs,
+    class Arg1, class Arg2, class T, class Shape>
+void einsum(
+    const einsum_arg<Arg1, Arg1Is...>& arg1,
+    const einsum_arg<Arg2, Arg2Is...>& arg2,
+    const einsum_arg<array_ref<T, Shape>, ResultIs...>& result) {
+
+  constexpr size_t LoopRank = internal::variadic_max(Arg1Is..., Arg2Is..., ResultIs...) + 1;
+
+  const auto& result_dims = std::get<0>(result).shape().dims();
+
+  // Dimensions we take from the operands are reductions, i.e. they should
+  // have stride 0.
+  const auto& arg1_dims = internal::reductions(std::get<0>(arg1).shape().dims());
+  const auto& arg2_dims = internal::reductions(std::get<0>(arg2).shape().dims());
+
+  // Gather the dimensions identified by the indices.
+  auto reduction_shape = make_shape_from_tuple(internal::gather_dims(
+      std::make_index_sequence<LoopRank>(),
+      std::make_tuple(result_dims, std::get<1>(result)),
+      std::make_tuple(arg1_dims, std::get<1>(arg1)),
+      std::make_tuple(arg2_dims, std::get<1>(arg2))));
+
+  // Reinterpret the result as having a shape of the reduction dimensions.
+  auto reduction = reinterpret_shape(std::get<0>(result), reduction_shape);
+
+  auto op1 = std::get<0>(arg1);
+  auto op2 = std::get<0>(arg2);
+
+  for_each_index(reduction_shape, [&](const index_of_rank<LoopRank>& i) {
+    reduction(i) += op1(std::get<Arg1Is>(i)...) * op2(std::get<Arg2Is>(i)...);
+  });
+}
+
+
+}  // namespace nda
+
+#endif  // NDARRAY_IMAGE_H

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -27,7 +27,7 @@ using einsum_arg = std::tuple<Arg, index_sequence<Is...>>;
 // Make a dimension a reduction dimension (give it a constexpr stride 0).
 template <index_t Min, index_t Extent, index_t Stride>
 auto reduction(const dim<Min, Extent, Stride>& d) {
-  return dim<Min, Extent, 0>(d.min(), d.extent());
+  return broadcast_dim<Min, Extent>(d.min(), d.extent());
 }
 
 // Make all of the dimensions reduction dimensions.
@@ -163,7 +163,8 @@ auto ein(const array<T, Shape, Alloc>& op) {
 
 /** Compute an Einstein summation. This function allows one to specify
  * many kinds of array transformations and reductions using Einstein
- * notation.
+ * notation. See https://en.wikipedia.org/wiki/Einstein_notation for more
+ * information about the notation itself.
  *
  * This function accepts a list of arguments arg1, arg2, ... result.
  * Each argument is the result of the `ein<i, j, ...>(arg)` helper

--- a/examples/linear_algebra/einsum.h
+++ b/examples/linear_algebra/einsum.h
@@ -47,8 +47,10 @@ template <class Dim1>
 auto reconcile_dim(const Dim1& dim1) { return dim1; }
 template <class Dim1, class Dim2>
 auto reconcile_dim(const Dim1& dim1, const Dim2& dim2) {
-  assert(dim1.stride() != 0 || dim2.stride() != 0 || dim1.min() == dim2.min());
-  assert(dim1.stride() != 0 || dim2.stride() != 0 || dim1.max() == dim2.max());
+  // If both dims are broadcasts, the intervals should match.
+  assert(dim1.stride() != 0 || dim2.stride() != 0 || dim1 == dim2);
+  // dim2 will be accessed with dim1's bounds, so check this is possible.
+  assert(dim2.is_in_range(dim1));
   return dim1;
 }
 

--- a/examples/linear_algebra/matrix.cpp
+++ b/examples/linear_algebra/matrix.cpp
@@ -173,17 +173,11 @@ void multiply_einsum_tiles(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_
   constexpr index_t tile_rows = 4;
   constexpr index_t tile_cols = vector_size * 3;
 
-  // Define an automatic storage allocator for the result of each tile.
-  uninitialized_auto_allocator<T, tile_rows*tile_cols, vector_size*sizeof(T)> tile_allocator;
-
   for (auto io : split<tile_rows>(c.i())) {
     for (auto jo : split<tile_cols>(c.j())) {
-      // Perform the matrix multiplication for this tile.
-      auto result_tile =
-          make_einsum<T, i, j>(ein<i, k>(a(io, _)), ein<k, j>(b(_, jo)), tile_allocator);
-
-      // Copy the accumulators to the output.
-      copy(result_tile, c(io, jo));
+      auto c_ijo = c(io, jo);
+      fill(c_ijo, static_cast<T>(0));
+      einsum(ein<i, k>(a), ein<k, j>(b), ein<i, j>(c_ijo));
     }
   }
 }

--- a/examples/linear_algebra/matrix.cpp
+++ b/examples/linear_algebra/matrix.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "matrix.h"
+#include "einsum.h"
 #include "benchmark.h"
 
 #include <random>
@@ -147,6 +148,12 @@ void multiply_reduce_tiles(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_
   }
 }
 
+template <class T>
+void multiply_einsum(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_ref<T> c) {
+  fill(c, static_cast<T>(0));
+  einsum(ein<0, 2>(a), ein<2, 1>(b), ein<0, 1>(c));
+}
+
 float relative_error(float a, float b) {
   return std::abs(a - b) / std::max(a, b);
 }
@@ -181,6 +188,7 @@ int main(int, const char**) {
     { "reduce_cols", multiply_reduce_cols<float> },
     { "reduce_rows", multiply_reduce_rows<float> },
     { "reduce_tiles", multiply_reduce_tiles<float> },
+    { "einsum", multiply_einsum<float> },
   };
   for (auto i : versions) {
     // Compute the result using all matrix multiply methods.

--- a/examples/linear_algebra/matrix.cpp
+++ b/examples/linear_algebra/matrix.cpp
@@ -150,8 +150,9 @@ void multiply_reduce_tiles(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_
 
 template <class T>
 void multiply_einsum(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_ref<T> c) {
-  fill(c, static_cast<T>(0));
   enum { i = 0, j = 1, k = 2 };
+
+  fill(c, static_cast<T>(0));
   einsum(ein<i, k>(a), ein<k, j>(b), ein<i, j>(c));
 }
 

--- a/examples/linear_algebra/matrix.cpp
+++ b/examples/linear_algebra/matrix.cpp
@@ -173,14 +173,14 @@ void multiply_einsum_tiles(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_
   constexpr index_t tile_rows = 4;
   constexpr index_t tile_cols = vector_size * 3;
 
-  using tile_allocator =
-      uninitialized_auto_allocator<T, tile_rows*tile_cols, vector_size * sizeof(T)>;
+  // Define an automatic storage allocator for the result of each tile.
+  uninitialized_auto_allocator<T, tile_rows*tile_cols, vector_size*sizeof(T)> tile_allocator;
 
   for (auto io : split<tile_rows>(c.i())) {
     for (auto jo : split<tile_cols>(c.j())) {
       // Perform the matrix multiplication for this tile.
       auto result_tile =
-          make_einsum<T, i, j>(ein<i, k>(a(io, _)), ein<k, j>(b(_, jo)), tile_allocator());
+          make_einsum<T, i, j>(ein<i, k>(a(io, _)), ein<k, j>(b(_, jo)), tile_allocator);
 
       // Copy the accumulators to the output.
       copy(result_tile, c(io, jo));

--- a/examples/linear_algebra/matrix.cpp
+++ b/examples/linear_algebra/matrix.cpp
@@ -151,7 +151,8 @@ void multiply_reduce_tiles(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_
 template <class T>
 void multiply_einsum(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_ref<T> c) {
   fill(c, static_cast<T>(0));
-  einsum(ein<0, 2>(a), ein<2, 1>(b), ein<0, 1>(c));
+  enum { i = 0, j = 1, k = 2 };
+  einsum(ein<i, k>(a), ein<k, j>(b), ein<i, j>(c));
 }
 
 float relative_error(float a, float b) {

--- a/examples/linear_algebra/matrix.cpp
+++ b/examples/linear_algebra/matrix.cpp
@@ -173,11 +173,14 @@ void multiply_einsum_tiles(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_
   constexpr index_t tile_rows = 4;
   constexpr index_t tile_cols = vector_size * 3;
 
+  using tile_allocator =
+      uninitialized_auto_allocator<T, tile_rows*tile_cols, vector_size * sizeof(T)>;
+
   for (auto io : split<tile_rows>(c.i())) {
     for (auto jo : split<tile_cols>(c.j())) {
       // Perform the matrix multiplication for this tile.
       auto result_tile =
-          make_einsum<T, i, j>(ein<i, k>(a(io, _)), ein<k, j>(b(_, jo)));
+          make_einsum<T, i, j>(ein<i, k>(a(io, _)), ein<k, j>(b(_, jo)), tile_allocator());
 
       // Copy the accumulators to the output.
       copy(result_tile, c(io, jo));

--- a/examples/linear_algebra/matrix.cpp
+++ b/examples/linear_algebra/matrix.cpp
@@ -21,6 +21,9 @@
 
 using namespace nda;
 
+// Useful named dimension indices for einsum.
+enum { i = 0, j = 1, k = 2 };
+
 // A textbook implementation of matrix multiplication. This is very simple,
 // but it is slow, primarily because of poor locality of the loads of b. The
 // reduction loop is innermost.
@@ -69,6 +72,14 @@ void multiply_reduce_rows(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_r
       }
     }
   }
+}
+
+// This implementation uses Einstein summation. This should be equivalent
+// to writing a reduction loop outermost implementation.
+template <class T>
+void multiply_einsum(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_ref<T> c) {
+  fill(c, static_cast<T>(0));
+  einsum(ein<i, k>(a), ein<k, j>(b), ein<i, j>(c));
 }
 
 // This implementation of matrix multiplication splits the loops over
@@ -148,12 +159,30 @@ void multiply_reduce_tiles(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_
   }
 }
 
-template <class T>
-void multiply_einsum(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_ref<T> c) {
-  enum { i = 0, j = 1, k = 2 };
+// I think when LLVM fixes https://bugs.llvm.org/show_bug.cgi?id=45863, this
+// will generate equivalent code to multiply_reduce_tiles!
+template <typename T>
+__attribute__((noinline))
+void multiply_einsum_tiles(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_ref<T> c) {
+  // Adjust this depending on the target architecture. For AVX2,
+  // vectors are 256-bit.
+  constexpr index_t vector_size = 32 / sizeof(T);
 
-  fill(c, static_cast<T>(0));
-  einsum(ein<i, k>(a), ein<k, j>(b), ein<i, j>(c));
+  // We want the tiles to be as big as possible without spilling any
+  // of the accumulator registers to the stack.
+  constexpr index_t tile_rows = 4;
+  constexpr index_t tile_cols = vector_size * 3;
+
+  for (auto io : split<tile_rows>(c.i())) {
+    for (auto jo : split<tile_cols>(c.j())) {
+      // Perform the matrix multiplication for this tile.
+      auto result_tile =
+          make_einsum<T, i, j>(ein<i, k>(a(io, _)), ein<k, j>(b(_, jo)));
+
+      // Copy the accumulators to the output.
+      copy(result_tile, c(io, jo));
+    }
+  }
 }
 
 float relative_error(float a, float b) {
@@ -189,8 +218,9 @@ int main(int, const char**) {
   version versions[] = {
     { "reduce_cols", multiply_reduce_cols<float> },
     { "reduce_rows", multiply_reduce_rows<float> },
-    { "reduce_tiles", multiply_reduce_tiles<float> },
     { "einsum", multiply_einsum<float> },
+    { "reduce_tiles", multiply_reduce_tiles<float> },
+    { "einsum_tiles", multiply_einsum_tiles<float> },
   };
   for (auto i : versions) {
     // Compute the result using all matrix multiply methods.

--- a/test/errors.cpp
+++ b/test/errors.cpp
@@ -34,12 +34,6 @@ void range_bad_assign() {
   x = interval<0, 2>();
 }
 
-void range_bad_equality() {
-  fixed_interval<3> x;
-  interval<0, 2> y;
-  x == y;
-}
-
 void dim_dim_bad_copy_construct() {
   dim<0, 1, 2> strided;
   dense_dim<> x2(strided);
@@ -48,12 +42,6 @@ void dim_dim_bad_copy_construct() {
 void dim_bad_assign() {
   dense_dim<> x;
   x = dim<0, 1, 2>();
-}
-
-void dim_bad_equality() {
-  dense_dim<> x;
-  dim<0, 1, 2> y;
-  x == y;
 }
 
 void shape_dim_bad_index() {


### PR DESCRIPTION
There's still a lot that could be done here, but this turned out to be fairly complete as a zero cost compile-time abstraction for Einstein summation.

This lacks any kind of clever optimization, but when this is used inside a manual tiling loop, it is still very expressive and should produce good performance with no overhead (see `multiply_einsum_tiles` for example, although it doesn't actually produce good performance today, hopefully due only to https://bugs.llvm.org/show_bug.cgi?id=45863).