### PR TITLE
Add implicit conversion to value_type for scalar-shaped arrays

### DIFF
--- a/array.h
+++ b/array.h
@@ -1891,6 +1891,12 @@ class array_ref {
   const const_array_ref<T, Shape> cref() const { return const_array_ref<T, Shape>(base_, shape_); }
   operator const_array_ref<T, Shape>() const { return cref(); }
 
+  /** Implicit conversion to `T` for scalar shaped array_refs. */
+  operator const_reference() const {
+    static_assert(rank() == 0, "Cannot convert non-scalar array to scalar.");
+    return *base_;
+  }
+
   /** Change the shape of the array to `new_shape`, and move the base pointer
    * by `offset`. The new shape must be a subset of the old shape. */
   void set_shape(const Shape& new_shape, index_t offset = 0) {
@@ -2371,6 +2377,16 @@ class array {
   const_array_ref<T, Shape> ref() const { return cref(); }
   operator array_ref<T, Shape>() { return ref(); }
   operator const_array_ref<T, Shape>() const { return cref(); }
+
+  /** Implicit conversion to `T` for scalar shaped arrays. */
+  operator reference() {
+    static_assert(rank() == 0, "Cannot convert non-scalar array to scalar.");
+    return *base_;
+  }
+  operator const_reference() const {
+    static_assert(rank() == 0, "Cannot convert non-scalar array to scalar.");
+    return *base_;
+  }
 };
 
 /** An array type with an arbitrary shape of rank `Rank`. */

--- a/array.h
+++ b/array.h
@@ -1892,7 +1892,7 @@ class array_ref {
   operator const_array_ref<T, Shape>() const { return cref(); }
 
   /** Implicit conversion to `T` for scalar shaped array_refs. */
-  operator const_reference() const {
+  operator reference() const {
     static_assert(rank() == 0, "Cannot convert non-scalar array to scalar.");
     return *base_;
   }

--- a/examples/linear_algebra/matrix.cpp
+++ b/examples/linear_algebra/matrix.cpp
@@ -48,7 +48,7 @@ __attribute__((noinline))
 void multiply_einsum_cols(const_matrix_ref<T> a, const_matrix_ref<T> b, matrix_ref<T> c) {
   for (index_t i : c.i()) {
     for (index_t j : c.j()) {
-      c(i, j) = make_einsum<T>(ein<k>(a(i, _)), ein<k>(b(_, j)))();
+      c(i, j) = make_einsum<T>(ein<k>(a(i, _)), ein<k>(b(_, j)));
     }
   }
 }

--- a/test/einsum.cpp
+++ b/test/einsum.cpp
@@ -42,7 +42,7 @@ TEST(einsum_trace) {
   matrix<int, N, N> A;
   fill_pattern(A);
 
-  int tr = make_einsum<int>(ein<i, i>(A))();
+  int tr = make_einsum<int>(ein<i, i>(A));
   int tr_ref = 0;
   for (index_t i : A.i()) {
     tr_ref += A(i, i);
@@ -83,7 +83,7 @@ TEST(einsum_dot_sq) {
   fill_pattern(x);
   fill_pattern(y);
 
-  int dot_sq = make_einsum<int>(ein<i>(x), ein<i>(x), ein<i>(y), ein<i>(y))();
+  int dot_sq = make_einsum<int>(ein<i>(x), ein<i>(x), ein<i>(y), ein<i>(y));
   int dot_sq_ref = 0;
   for (index_t i : x.i()) {
     dot_sq_ref += x(i) * x(i) * y(i) * y(i);


### PR DESCRIPTION
Not completely sure this is a good idea, but it makes `make_einsum` a bit nicer for scalar results...