### PR TITLE
Add CUDA blurb to readme, and small tweaks to build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,11 @@
 CFLAGS := $(CFLAGS) -O2 -ffast-math -fstrict-aliasing -march=native
 CXXFLAGS := $(CXXFLAGS) -std=c++14 -Wall
 LDFLAGS := $(LDFLAGS)
-CUDA_FLAGS := --cuda-gpu-arch=sm_52 -nocudalib -nocudainc -emit-llvm
 
 DEPS := array.h einsum.h image.h matrix.h
 
 TEST_SRC := $(filter-out test/errors.cpp, $(wildcard test/*.cpp))
 TEST_OBJ := $(TEST_SRC:%.cpp=obj/%.o)
-
-# TODO(jiawen): Add CUDA support to image.h, matrix.h, and einsum.h.
-# Then we can get rid of this dep.
-CUDA_DEPS := array.h
 
 # Note that .cu files are automatically compiled by clang as CUDA.
 # Other extensions will need "-x cuda".
@@ -24,14 +19,16 @@ bin/test: $(TEST_OBJ)
 	mkdir -p $(@D)
 	$(CXX) -o $@ $^ $(LDFLAGS) -lstdc++ -lm
 
-cuda_build_test: $(CUDA_TEST_SRC) $(CUDA_DEPS)
-	$(CXX) -I. -c $< $(CFLAGS) $(CXXFLAGS) $(CUDA_FLAGS)
-	
+cuda_build_test: $(CUDA_TEST_SRC) $(DEPS)
+	$(CXX) -I. -c $< $(CFLAGS) $(CXXFLAGS) --cuda-gpu-arch=sm_52 -nocudalib -nocudainc -emit-llvm
+	# TODO: Figure out how to run this build test to produce outputs in bin/ or obj/
+	rm *.bc
+
 .PHONY: all clean test
 
 clean:
-	rm -rf obj/* bin/* *.bc *.gch
+	rm -rf obj/* bin/*
 
 test: bin/test
-	bin/test $(FILTER)
 	@! $(CXX) -I. -c test/errors.cpp -std=c++14 -Wall -ferror-limit=0 2>&1 | grep "error:" | grep array.h
+	bin/test $(FILTER)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Arrays efficiently support advanced manipulations like cropping, slicing, and sp
 Although it is a heavily templated library, most features do not have significant code size or compile time implications, and incorrect usage generates informative and helpful error messages.
 Typically, an issue will result in only one error message, located at the site of the problem in user code.
 
+Many of the tools provided by this library can be used in `__device__` code compiled with [CUDA](https://developer.nvidia.com/cuda-zone).
+
 Many other libraries offering multi-dimensional arrays or tensors allow compile-time constant shapes.
 *However*, most if not all of them only allow either all of the shape parameters to be compile-time constant, or none of them.
 This is really limiting; often only a few key parameters of a shape need to be compile-time constant for performance, while other dimensions need flexibility to accommodate runtime-valued shape parameters.
@@ -240,3 +242,9 @@ The behavior of each kind of split is different:
 
 Compile-time constant split factors produce ranges with compile-time extents, and shapes and arrays cropped with these ranges will have a corresponding `dim<>` with a compile-time constant extent.
 This allows potentially significant optimizations to be expressed relatively easily!
+
+### CUDA support
+
+Most of the functions in this library are marked with `__device__`, enabling them to be used in CUDA code.
+This includes `array_ref<T, Shape>` and most of its helper functions.
+The exceptions to this are functions allocating memory, primarily `array<T, Shape, Alloc>`.

--- a/README.md
+++ b/README.md
@@ -247,4 +247,4 @@ This allows potentially significant optimizations to be expressed relatively eas
 
 Most of the functions in this library are marked with `__device__`, enabling them to be used in CUDA code.
 This includes `array_ref<T, Shape>` and most of its helper functions.
-The exceptions to this are functions allocating memory, primarily `array<T, Shape, Alloc>`.
+The exceptions to this are functions and classes that allocate memory, primarily `array<T, Shape, Alloc>`.

--- a/test/build_test.cu
+++ b/test/build_test.cu
@@ -32,7 +32,7 @@ NDARRAY_HOST_DEVICE
 void reinterpret() {
   float eight = 8.0f;
   int eight_int = *reinterpret_cast<int*>(&eight);
-  
+
   dense_array_ref<int, 3> int_array(&eight_int, {1, 1, 1});
   dense_array_ref<float, 3> float_array = reinterpret<float>(int_array);
   (void)int_array;
@@ -42,15 +42,19 @@ void reinterpret() {
 NDARRAY_HOST_DEVICE
 void array_ref_empty() {
   // This does *not* work: it that shape_ = new_shape is not allowed because we use the
-  // defaulted assignment operator, which is apparently __host__ only?
-  // I.e., shape& operator=(const shape&) = default;
-  // 
+  // defaulted assignment operator, which is apparently __host__ only? This seems
+  // like a bug in clang, the operator is explicitly defaulted with a __device__ annotation:
+  //   NDARRAY_HOST_DEVICE
+  //   shape& operator=(const shape&) = default;
+  //
   // dense_array_ref<int, 1> null_ref(nullptr, {10});
   // null_ref.set_shape({{3, 3}}, 3);
-  
+
   int x;
   array_ref_of_rank<int, 0> scalar_ref(&x, {});
   array_ref_of_rank<int, 0> null_scalar_ref(nullptr, {});
 }
+
+// TODO(jiawen): Add CUDA support to image.h, matrix.h, and einsum.h.
 
 }  // namespace nda


### PR DESCRIPTION
- Added some short docs about CUDA support to the readme.
- Tweaked Makefile to try to get the outputs to go in bin/ obj/ but failed.
- Drive-by change to run the errors test first, since it's fast, and it's annoying to wait for the performance tests to run when checking this.