### PR TITLE
Add tests that function-accepting functions do not copy the function.

### DIFF
--- a/array.h
+++ b/array.h
@@ -1752,7 +1752,7 @@ template <size_t... LoopOrder, class Shape, class Fn,
     std::enable_if_t<(sizeof...(LoopOrder) == 0), int> = 0>
 NDARRAY_UNIQUE NDARRAY_HOST_DEVICE void for_all_indices(const Shape& s, Fn&& fn) {
   using index_type = typename Shape::index_type;
-  for_each_index(s, [&](const index_type& i) { internal::apply(fn, i); });
+  for_each_index(s, [fn = std::move(fn)](const index_type& i) { internal::apply(fn, i); });
 }
 template <size_t... LoopOrder, class Shape, class Fn,
     class = internal::enable_if_callable<Fn, index_of_rank<sizeof...(LoopOrder)>>,
@@ -1760,15 +1760,16 @@ template <size_t... LoopOrder, class Shape, class Fn,
 NDARRAY_UNIQUE NDARRAY_HOST_DEVICE void for_each_index(const Shape& s, Fn&& fn) {
   using index_type = index_of_rank<sizeof...(LoopOrder)>;
   for_each_index_in_order(reorder<LoopOrder...>(s),
-      [&](const index_type& i) { fn(internal::unshuffle<LoopOrder...>(i)); });
+      [fn = std::move(fn)](const index_type& i) { fn(internal::unshuffle<LoopOrder...>(i)); });
 }
 template <size_t... LoopOrder, class Shape, class Fn,
     class = internal::enable_if_callable<Fn, decltype(LoopOrder)...>,
     std::enable_if_t<(sizeof...(LoopOrder) != 0), int> = 0>
 NDARRAY_UNIQUE NDARRAY_HOST_DEVICE void for_all_indices(const Shape& s, Fn&& fn) {
   using index_type = index_of_rank<sizeof...(LoopOrder)>;
-  for_each_index_in_order(reorder<LoopOrder...>(s),
-      [&](const index_type& i) { internal::apply(fn, internal::unshuffle<LoopOrder...>(i)); });
+  for_each_index_in_order(reorder<LoopOrder...>(s), [fn = std::move(fn)](const index_type& i) {
+    internal::apply(fn, internal::unshuffle<LoopOrder...>(i));
+  });
 }
 
 template <class T, class Shape>

--- a/array.h
+++ b/array.h
@@ -1441,7 +1441,8 @@ template <class Shape, class Ptr, class Fn,
     class = internal::enable_if_callable<Fn, typename std::remove_pointer<Ptr>::type&>>
 NDARRAY_UNIQUE NDARRAY_HOST_DEVICE void for_each_value_in_order(
     const Shape& shape, Ptr base, Fn&& fn) {
-  for_each_index_in_order(shape, [=](const typename Shape::index_type& i) { fn(base[shape(i)]); });
+  for_each_index_in_order(
+      shape, [=, fn = std::move(fn)](const typename Shape::index_type& i) { fn(base[shape(i)]); });
 }
 
 /** Similar to `for_each_value_in_order`, but iterates over two arrays
@@ -1452,8 +1453,9 @@ template <class Shape, class ShapeA, class PtrA, class ShapeB, class PtrB, class
         typename std::remove_pointer<PtrB>::type&>>
 NDARRAY_UNIQUE NDARRAY_HOST_DEVICE void for_each_value_in_order(const Shape& shape,
     const ShapeA& shape_a, PtrA base_a, const ShapeB& shape_b, PtrB base_b, Fn&& fn) {
-  for_each_index_in_order(shape,
-      [=](const typename Shape::index_type& i) { fn(base_a[shape_a(i)], base_b[shape_b(i)]); });
+  for_each_index_in_order(shape, [=, fn = std::move(fn)](const typename Shape::index_type& i) {
+    fn(base_a[shape_a(i)], base_b[shape_b(i)]);
+  });
 }
 
 namespace internal {

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -341,7 +341,8 @@ TEST(array_tricky_copy) {
 
 TEST(array_for_each_value_scalar) {
   array_of_rank<int, 0> scalar;
-  scalar.for_each_value([token = no_copy{no_copy()}](int& v) {
+  move_only token;
+  scalar.for_each_value([token = std::move(token)](int& v) {
     v = 3;
     assert_used(token);
   });
@@ -353,7 +354,8 @@ TEST(array_for_each_value) {
   array_of_rank<int, 3> out_of_order({{0, 4, 16}, {0, 4, 1}, {0, 4, 4}});
 
   int out_of_order_counter = 0;
-  out_of_order.for_each_value([&, token = no_copy{no_copy()}](int& v) {
+  move_only token;
+  out_of_order.for_each_value([&, token = std::move(token)](int& v) {
     v = out_of_order_counter++;
     assert_used(token);
   });

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -341,7 +341,10 @@ TEST(array_tricky_copy) {
 
 TEST(array_for_each_value_scalar) {
   array_of_rank<int, 0> scalar;
-  scalar.for_each_value([](int& v) { v = 3; });
+  scalar.for_each_value([token = no_copy{no_copy()}](int& v) {
+    v = 3;
+    assert_used(token);
+  });
   ASSERT_EQ(scalar(), 3);
 }
 
@@ -350,7 +353,10 @@ TEST(array_for_each_value) {
   array_of_rank<int, 3> out_of_order({{0, 4, 16}, {0, 4, 1}, {0, 4, 4}});
 
   int out_of_order_counter = 0;
-  out_of_order.for_each_value([&](int& v) { v = out_of_order_counter++; });
+  out_of_order.for_each_value([&, token = no_copy{no_copy()}](int& v) {
+    v = out_of_order_counter++;
+    assert_used(token);
+  });
 
   int in_order_counter = 0;
   in_order.for_each_value([&](int& v) { v = in_order_counter++; });

--- a/test/shape.cpp
+++ b/test/shape.cpp
@@ -226,7 +226,10 @@ TEST(clamp) {
 TEST(for_all_indices_scalar) {
   shape<> s;
   int count = 0;
-  for_all_indices(s, [&]() { count++; });
+  for_all_indices(s, [&, token = no_copy{no_copy()}]() {
+    count++;
+    assert_used(token);
+  });
   ASSERT_EQ(count, 1);
 }
 
@@ -257,9 +260,10 @@ TEST(for_all_indices_3d) {
   dense_shape<3> s(3, 5, 8);
   s.resolve();
   int expected_flat_offset = 0;
-  for_all_indices(s, [&](int x, int y, int z) {
+  for_all_indices(s, [&, token = no_copy{no_copy()}](int x, int y, int z) {
     ASSERT_EQ(s(x, y, z), expected_flat_offset);
     expected_flat_offset++;
+    assert_used(token);
   });
   // Ensure the for_all_indices loop above actually ran.
   ASSERT_EQ(expected_flat_offset, 120);
@@ -269,9 +273,10 @@ TEST(for_all_indices_3d_reordered) {
   shape_of_rank<3> s(3, 5, {0, 8, 1});
   s.resolve();
   int expected_flat_offset = 0;
-  for_all_indices<2, 0, 1>(s, [&](int x, int y, int z) {
+  for_all_indices<2, 0, 1>(s, [&, token = no_copy{no_copy()}](int x, int y, int z) {
     ASSERT_EQ(s(x, y, z), expected_flat_offset);
     expected_flat_offset++;
+    assert_used(token);
   });
   // Ensure the for_all_indices loop above actually ran.
   ASSERT_EQ(expected_flat_offset, 120);
@@ -280,7 +285,10 @@ TEST(for_all_indices_3d_reordered) {
 TEST(for_each_index_scalar) {
   shape<> s;
   int count = 0;
-  for_each_index(s, [&](std::tuple<>) { count++; });
+  for_each_index(s, [&, token = no_copy{no_copy()}](std::tuple<>) {
+    count++;
+    assert_used(token);
+  });
   ASSERT_EQ(count, 1);
 }
 
@@ -311,9 +319,10 @@ TEST(for_each_index_3d) {
   dense_shape<3> s(3, 5, 8);
   s.resolve();
   int expected_flat_offset = 0;
-  for_each_index(s, [&](std::tuple<int, int, int> x) {
+  for_each_index(s, [&, token = no_copy{no_copy()}](std::tuple<int, int, int> x) {
     ASSERT_EQ(s(x), expected_flat_offset);
     expected_flat_offset++;
+    assert_used(token);
   });
   // Ensure the for_each_index loop above actually ran.
   ASSERT_EQ(expected_flat_offset, 120);
@@ -323,9 +332,10 @@ TEST(for_each_index_3d_reorderd) {
   shape_of_rank<3> s(3, 5, {0, 8, 1});
   s.resolve();
   int expected_flat_offset = 0;
-  for_each_index<2, 0, 1>(s, [&](std::tuple<int, int, int> x) {
+  for_each_index<2, 0, 1>(s, [&, token = no_copy{no_copy()}](std::tuple<int, int, int> x) {
     ASSERT_EQ(s(x), expected_flat_offset);
     expected_flat_offset++;
+    assert_used(token);
   });
   // Ensure the for_each_index loop above actually ran.
   ASSERT_EQ(expected_flat_offset, 120);

--- a/test/shape.cpp
+++ b/test/shape.cpp
@@ -226,7 +226,8 @@ TEST(clamp) {
 TEST(for_all_indices_scalar) {
   shape<> s;
   int count = 0;
-  for_all_indices(s, [&, token = no_copy{no_copy()}]() {
+  move_only token;
+  for_all_indices(s, [&, token = std::move(token)]() {
     count++;
     assert_used(token);
   });
@@ -260,7 +261,8 @@ TEST(for_all_indices_3d) {
   dense_shape<3> s(3, 5, 8);
   s.resolve();
   int expected_flat_offset = 0;
-  for_all_indices(s, [&, token = no_copy{no_copy()}](int x, int y, int z) {
+  move_only token;
+  for_all_indices(s, [&, token = std::move(token)](int x, int y, int z) {
     ASSERT_EQ(s(x, y, z), expected_flat_offset);
     expected_flat_offset++;
     assert_used(token);
@@ -273,7 +275,8 @@ TEST(for_all_indices_3d_reordered) {
   shape_of_rank<3> s(3, 5, {0, 8, 1});
   s.resolve();
   int expected_flat_offset = 0;
-  for_all_indices<2, 0, 1>(s, [&, token = no_copy{no_copy()}](int x, int y, int z) {
+  move_only token;
+  for_all_indices<2, 0, 1>(s, [&, token = std::move(token)](int x, int y, int z) {
     ASSERT_EQ(s(x, y, z), expected_flat_offset);
     expected_flat_offset++;
     assert_used(token);
@@ -297,7 +300,8 @@ TEST(for_all_indices_2d_of_3d) {
 TEST(for_each_index_scalar) {
   shape<> s;
   int count = 0;
-  for_each_index(s, [&, token = no_copy{no_copy()}](std::tuple<>) {
+  move_only token;
+  for_each_index(s, [&, token = std::move(token)](std::tuple<>) {
     count++;
     assert_used(token);
   });
@@ -331,7 +335,8 @@ TEST(for_each_index_3d) {
   dense_shape<3> s(3, 5, 8);
   s.resolve();
   int expected_flat_offset = 0;
-  for_each_index(s, [&, token = no_copy{no_copy()}](std::tuple<int, int, int> i) {
+  move_only token;
+  for_each_index(s, [&, token = std::move(token)](std::tuple<int, int, int> i) {
     ASSERT_EQ(s(i), expected_flat_offset);
     expected_flat_offset++;
     assert_used(token);
@@ -344,7 +349,8 @@ TEST(for_each_index_3d_reorderd) {
   shape_of_rank<3> s(3, 5, {0, 8, 1});
   s.resolve();
   int expected_flat_offset = 0;
-  for_each_index<2, 0, 1>(s, [&, token = no_copy{no_copy()}](std::tuple<int, int, int> i) {
+  move_only token;
+  for_each_index<2, 0, 1>(s, [&, token = std::move(token)](std::tuple<int, int, int> i) {
     ASSERT_EQ(s(i), expected_flat_offset);
     expected_flat_offset++;
     assert_used(token);

--- a/test/test.h
+++ b/test/test.h
@@ -207,12 +207,12 @@ __attribute__((noinline)) T not_constant(T x) {
 }
 
 // This type generates compiler errors if it is copied.
-struct no_copy {
-  no_copy() = default;
-  no_copy(no_copy&&) = default;
-  no_copy& operator=(no_copy&&) = default;
-  no_copy(const no_copy&) = delete;
-  no_copy& operator=(const no_copy&) = delete;
+struct move_only {
+  move_only() = default;
+  move_only(move_only&&) = default;
+  move_only& operator=(move_only&&) = default;
+  move_only(const move_only&) = delete;
+  move_only& operator=(const move_only&) = delete;
 };
 
 } // namespace nda

--- a/test/test.h
+++ b/test/test.h
@@ -206,6 +206,15 @@ __attribute__((noinline)) T not_constant(T x) {
   return x;
 }
 
+// This type generates compiler errors if it is copied.
+struct no_copy {
+  no_copy() = default;
+  no_copy(no_copy&&) = default;
+  no_copy& operator=(no_copy&&) = default;
+  no_copy(const no_copy&) = delete;
+  no_copy& operator=(const no_copy&) = delete;
+};
+
 } // namespace nda
 
 #endif // NDARRAY_TEST_TEST_H


### PR DESCRIPTION
Verified this works by making part of the for_each_index implementation take the function by value, the build broke.