### PR TITLE
Remove make_dense and friends

### DIFF
--- a/examples/resample/resample.cpp
+++ b/examples/resample/resample.cpp
@@ -56,9 +56,11 @@ chunky_image_ref<const Magick::Quantum, 4> cref(const Magick::Image& img) {
 
 template <class T>
 planar_image<T> magick_to_array(const Magick::Image& img) {
-  // We can tell make_dense_copy the value_type of the array we want by giving
+  // We can tell make_compact_copy the value_type of the array we want by giving
   // it an allocator for that type.
-  return make_dense_copy(cref(img), std::allocator<T>());
+  auto chunky = cref(img);
+  planar_image_shape array_shape(chunky.width(), chunky.height(), chunky.channels());
+  return make_copy(chunky, array_shape, std::allocator<T>());
 }
 
 template <class T, class Shape>

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -315,7 +315,7 @@ TEST(array_dense_copy) {
   fill_pattern(source);
   ASSERT(!source.is_compact());
 
-  dense_array<int, 3> dense_copy = make_dense_copy(source);
+  dense_array<int, 3> dense_copy = make_compact_copy(source);
   ASSERT(dense_copy.is_compact());
   check_pattern(dense_copy);
 }
@@ -325,7 +325,7 @@ TEST(array_dense_move) {
   fill_pattern(source);
   ASSERT(!source.is_compact());
 
-  dense_array<int, 3> dense_move = make_dense_move(source);
+  dense_array<int, 3> dense_move = make_compact_move(source);
   ASSERT(dense_move.is_compact());
   check_pattern(dense_move);
 }
@@ -417,7 +417,7 @@ TEST(array_negative_strides) {
   ASSERT_EQ(a.x().stride(), 3);
   for_all_indices(a.shape(), [&](int x, int y) { a(x, y) = y; });
 
-  dense_array<int, 2> b = make_dense_copy(a);
+  dense_array<int, 2> b = make_compact_copy(a);
   for_each_index(b.shape(),
       [&](const dense_array<int, 2>::index_type& i) { ASSERT_EQ(b(i), std::get<1>(i)); });
 }

--- a/test/array_ref.cpp
+++ b/test/array_ref.cpp
@@ -67,7 +67,7 @@ TEST(array_ref_copy) {
   }
 
   array_ref_of_rank<int, 1> evens(data, {dim<>(0, 50, 2)});
-  dense_array<int, 1> evens_copy = make_dense_copy(evens);
+  dense_array<int, 1> evens_copy = make_compact_copy(evens);
   for (int i = 0; i < 50; i++) {
     ASSERT_EQ(evens(i), i * 2);
     ASSERT_EQ(evens_copy(i), i * 2);


### PR DESCRIPTION
Now that `make_compact` produces a dense shape in the typical no-strides case, I think `make_dense` and related functions are unnecessary, but I'm not sure, @jiawen what do you think?

I think the best improvement if/after merging this would be to find a clean way of addressing #23, which in combination with make_compact, would be a 1:1 replacement for make_dense.