### PR TITLE
Use default initializer syntax to avoid redundant specification of co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,12 @@ A dimension with unknown min and extent, and stride 1, is common enough that it 
 There are other common examples that are easy to support.
 A very common array is an image where 3-channel RGB or 4-channel RGBA pixels are stored together in a 'chunky' format.
 ```c++
-template <int Channels, int PixelStride = Channels>
+template <int Channels, int XStride = Channels>
 using chunky_image_shape = shape<
-    strided_dim</*Stride=*/PixelStride>,
+    strided_dim</*Stride=*/XStride>,
     dim<>,
     dense_dim</*Min=*/0, /*Extent=*/Channels>>;
+array<uint8_t, chunky_image_shape<3>> my_chunky_image({1920, 1080, {}});
 ```
 
 `strided_dim<>` is another alias for `dim<>` where the min and extent are unknown, and the stride may be a compile-time constant.

--- a/test/image.cpp
+++ b/test/image.cpp
@@ -156,7 +156,7 @@ TEST(image_deinterleave) {
 }
 
 TEST(image_chunky_padded) {
-  chunky_image<int, 4> src({40, 30, 4});
+  chunky_image<int, 4> src({40, 30, {}});
   fill_pattern(src);
   chunky_image<int, 4> dest(src.shape(), 5);
 
@@ -188,7 +188,7 @@ TEST(image_overload_shape) {
   overload_shape(planar);
   overload_shape(chunky);
 
-  chunky_image<int, 3> chunky3({10, 20, 3});
+  chunky_image<int, 3> chunky3({10, 20, {}});
   general_chunky(chunky3.cref());
 }
 
@@ -196,8 +196,8 @@ void overload_chunky(const chunky_image_ref<const int, 1>&) {}
 void overload_chunky(const chunky_image_ref<const int, 3>&) {}
 
 TEST(image_overload_chunky) {
-  chunky_image<int, 1> chunky1({10, 20, 1});
-  chunky_image<int, 3> chunky3({10, 20, 3});
+  chunky_image<int, 1> chunky1({10, 20, {}});
+  chunky_image<int, 3> chunky3({10, 20, {}});
 
   overload_chunky(chunky1);
   overload_chunky(chunky3);

--- a/test/readme.cpp
+++ b/test/readme.cpp
@@ -17,6 +17,7 @@
 #include "test.h"
 
 #include <complex>
+#include <cstdint>
 
 namespace nda {
 
@@ -24,9 +25,10 @@ namespace nda {
 // to copy-paste them.
 
 // Define a compile-time "chunky" image shape.
-template <int Channels, int PixelStride = Channels>
+template <int Channels, int XStride = Channels>
 using chunky_image_shape =
-    shape<strided_dim</*Stride=*/PixelStride>, dim<>, dense_dim</*Min=*/0, /*Extent=*/Channels>>;
+    shape<strided_dim</*Stride=*/XStride>, dim<>, dense_dim</*Min=*/0, /*Extent=*/Channels>>;
+array<uint8_t, chunky_image_shape<3>> my_chunky_image({1920, 1080, {}});
 
 // Define a compile-time small matrix type, with the array data in
 // automatic storage.


### PR DESCRIPTION
…mpile-time constants.