### PR TITLE
Add missing `#include <algorithm>`

### DIFF
--- a/array.h
+++ b/array.h
@@ -19,6 +19,7 @@
 #ifndef NDARRAY_ARRAY_H
 #define NDARRAY_ARRAY_H
 
+#include <algorithm>
 #include <array>
 // TODO(jiawen): CUDA *should* support assert on device. This might be due to the fact that we are
 // not depending on the CUDA toolkit.


### PR DESCRIPTION
An upcoming compiler release updates libc++ to stop exporting `<algorithm>`
from certain headers [1]. This means code using functions from `<algorithm>`
but relying on them existing from transitive header dependencies will now be
broken.

[1] The commit: https://github.com/llvm/llvm-project/commit/2e2f3158c604adb8401a2a44a03f58d4b6f1c7f9