### PR TITLE
Adds variant of make_copy that doesn't need the destination shape.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
 cc_test(
     name = "array_test",
     srcs = [
+        "test/array.cpp",
         "test/ein_reduce.cpp",
         "test/image.cpp",
         "test/lifetime.cpp",

--- a/array.h
+++ b/array.h
@@ -2614,6 +2614,20 @@ void copy(const array<TSrc, ShapeSrc, AllocSrc>& src, array<TDst, ShapeDst, Allo
   copy(src.cref(), dst.ref());
 }
 
+/** Make a copy of the `src` array or array_ref with a new allocator `alloc`. */
+template <class T, class ShapeSrc,
+    class Alloc = std::allocator<typename std::remove_const<T>::type>>
+auto make_copy(const array_ref<T, ShapeSrc>& src, const Alloc& alloc = Alloc()) {
+  array<typename std::allocator_traits<Alloc>::value_type, ShapeSrc, Alloc> dst(src.shape(), alloc);
+  copy(src, dst);
+  return dst;
+}
+template <class T, class ShapeSrc, class AllocSrc, class AllocDst = AllocSrc,
+    class = internal::enable_if_allocator<AllocDst>>
+auto make_copy(const array<T, ShapeSrc, AllocSrc>& src, const AllocDst& alloc = AllocDst()) {
+  return make_copy(src.cref(), alloc);
+}
+
 /** Make a copy of the `src` array or array_ref with a new shape `shape`. */
 template <class T, class ShapeSrc, class ShapeDst,
     class Alloc = std::allocator<typename std::remove_const<T>::type>,

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -279,6 +279,27 @@ TEST(array_copy) {
   dense_array<int, 3> g({{1, 2}, {1, 3}, {1, 4}});
   copy(a, g);
   check_pattern(g);
+
+  array_of_rank<int, 3> h = make_copy(a);
+  check_pattern(h);
+
+  array_of_rank<int, 3, uninitialized_std_allocator<int>> h_uninitialized =
+      make_copy(a, uninitialized_std_allocator<int>());
+  check_pattern(h_uninitialized);
+
+  array_of_rank<int, 3> i = make_copy(a.ref());
+  check_pattern(i);
+
+  array_of_rank<int, 3, uninitialized_std_allocator<int>> i_uninitialized =
+      make_copy(a.ref(), uninitialized_std_allocator<int>());
+  check_pattern(i_uninitialized);
+
+  array_of_rank<int, 3> j = make_copy(a.cref());
+  check_pattern(i);
+
+  array_of_rank<int, 3, uninitialized_std_allocator<int>> j_uninitialized =
+      make_copy(a.cref(), uninitialized_std_allocator<int>());
+  check_pattern(j_uninitialized);
 }
 
 TEST(array_move) {


### PR DESCRIPTION
* Fixes missing array.cpp from Bazel test.