### PR TITLE
Add `fixed_dense_shape` (related to #65)

### DIFF
--- a/array.h
+++ b/array.h
@@ -1527,7 +1527,7 @@ NDARRAY_HOST_DEVICE auto make_compact(const Shape& s) {
   return static_compact;
 }
 
-/** A `shape` where all extents and strides are constant. */
+/** A `shape` where all extents (and automatically computed compact strides) are constant. */
 template <index_t... Extents>
 using fixed_dense_shape = decltype(make_shape_from_tuple(internal::make_compact_dims<1>(dim<0, Extents>()...)));
 

--- a/array.h
+++ b/array.h
@@ -1527,6 +1527,10 @@ NDARRAY_HOST_DEVICE auto make_compact(const Shape& s) {
   return static_compact;
 }
 
+/** A `shape` where all extents and strides are constant. */
+template <index_t... Extents>
+using fixed_dense_shape = decltype(make_shape_from_tuple(internal::make_compact_dims<1>(dim<0, Extents>()...)));
+
 /** Returns `true` if a shape `src` can be assigned to a shape of type
  * `ShapeDst` without error. */
 template <class ShapeDst, class ShapeSrc,

--- a/test/shape.cpp
+++ b/test/shape.cpp
@@ -526,6 +526,12 @@ TEST(shape_make_compact) {
   assert_shapes_eq(make_compact(s6), s6_compact);
 }
 
+TEST(shape_fixed_dense) { 
+  shape<dim<0, 2, 1>, dim<0, 3, 2>, dim<0, 4, 6>> s1;
+  fixed_dense_shape<2, 3, 4> s1_fixed;
+  assert_shapes_eq(s1, s1_fixed);
+}
+
 template <typename Shape>
 void test_number_theory(Shape s) {
   s.resolve();

--- a/test/shape.cpp
+++ b/test/shape.cpp
@@ -527,8 +527,8 @@ TEST(shape_make_compact) {
 }
 
 TEST(shape_fixed_dense) { 
-  shape<dim<0, 2, 1>, dim<0, 3, 2>, dim<0, 4, 6>> s1;
-  fixed_dense_shape<2, 3, 4> s1_fixed;
+  shape<dim<0, 2, 1>, dim<0, 3, 2>, dim<0, 4, 6>, dim<0, 5, 24>> s1;
+  fixed_dense_shape<2, 3, 4, 5> s1_fixed;
   assert_shapes_eq(s1, s1_fixed);
 }
 


### PR DESCRIPTION
This adds a helper shape type `fixed_dense_shape<Extents...>` that defines a fully constant shape. I think this is the "hard part" of #65, the rest is easily done in user code.