### PR TITLE
Add dim(size_t d) overload to class array

### DIFF
--- a/array.h
+++ b/array.h
@@ -2442,6 +2442,7 @@ public:
   const auto& dim() const {
     return shape_.template dim<D>();
   }
+  const nda::dim<> dim(size_t d) const { return shape_.dim(d); }
   size_type size() const { return shape_.size(); }
   bool empty() const { return shape_.empty(); }
   bool is_compact() const { return shape_.is_compact(); }


### PR DESCRIPTION
This mirrors the templated accessor added on array:

  template <size_t D, class = enable_if_dim<D> const auto& dim()

Both accessors still forward calls to the underlying shape_.