### PR TITLE
algorithm.cpp: Add initializer to pacify gcc

### DIFF
--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -122,7 +122,7 @@ TEST(transform_index) {
   ASSERT(a_0d() == 10);
 
   // 1D.
-  dense_array<int, 1> a_1d({1024});
+  dense_array<int, 1> a_1d({1024}, 0);
   transform_index(a_1d, pattern_1d);
   for (auto x : a_1d.x()) {
     ASSERT(a_1d(x) == pattern_1d(std::make_tuple(x)));


### PR DESCRIPTION
Before this change, `make test` gives:

```
g++ -I. -c -o obj/test/algorithm.o test/algorithm.cpp  -O2 -ffast-math -fstrict-aliasing -fPIE  -std=c++14 -Wall
test/algorithm.cpp: In function ‘void nda::test_transform_index_body()’:
test/algorithm.cpp:125:34: error: call of overloaded ‘array(<brace-enclosed initializer list>)’ is ambiguous
  125 |   dense_array<int, 1> a_1d({1024});
```