### PR TITLE
Use a new token `unresolved` instead of `dynamic` for unresolved strides

### DIFF
--- a/absl/absl.h
+++ b/absl/absl.h
@@ -19,7 +19,11 @@ void AbslStringify(Sink& sink, const interval<Min, Extent>& i) {
 // Stringifies only the values, not whether they are static or dynamic.
 template <typename Sink, index_t Min, index_t Extent, index_t Stride>
 void AbslStringify(Sink& sink, const dim<Min, Extent, Stride>& d) {
-  absl::Format(&sink, "dim(%v, %v, %v)", d.min(), d.extent(), d.stride());
+  if (internal::is_resolved(d.stride())) {
+    absl::Format(&sink, "dim(%v, %v, %v)", d.min(), d.extent(), d.stride());
+  } else {
+    absl::Format(&sink, "dim(%v, %v)", d.min(), d.extent());
+  }
 }
 
 // shape -> string as "shape<`rank`>(dims...).

--- a/absl/absl_test.cpp
+++ b/absl/absl_test.cpp
@@ -61,19 +61,19 @@ TEST(absl_stringify_dim) {
   {
     dim<> d;
     const std::string s = absl::StrFormat("%v", d);
-    ASSERT(s == "dim(0, 0, -9)");
+    ASSERT(s == "dim(0, 0)");
   }
 
   {
     dim<> d(/*extent=*/640);
     const std::string s = absl::StrFormat("%v", d);
-    ASSERT(s == "dim(0, 640, -9)");
+    ASSERT(s == "dim(0, 640)");
   }
 
   {
     dim<> d(/*min=*/35, /*extent=*/640);
     const std::string s = absl::StrFormat("%v", d);
-    ASSERT(s == "dim(35, 640, -9)");
+    ASSERT(s == "dim(35, 640)");
   }
 
   {
@@ -86,13 +86,13 @@ TEST(absl_stringify_dim) {
   {
     dim</*min=*/3> d;
     const std::string s = absl::StrFormat("%v", d);
-    ASSERT(s == "dim(3, 0, -9)");
+    ASSERT(s == "dim(3, 0)");
   }
 
   {
     dim</*min=*/-4, /*extent=*/5> d;
     const std::string s = absl::StrFormat("%v", d);
-    ASSERT(s == "dim(-4, 5, -9)");
+    ASSERT(s == "dim(-4, 5)");
   }
 
   {
@@ -114,20 +114,20 @@ TEST(absl_stringify_shape) {
   {
     shape_of_rank<1> sh;
     const std::string s = absl::StrFormat("%v", sh);
-    ASSERT(s == "shape<1>(dim(0, 0, -9))");
+    ASSERT(s == "shape<1>(dim(0, 0))");
   }
 
   {
     shape_of_rank<3> sh;
     const std::string s = absl::StrFormat("%v", sh);
-    ASSERT(s == "shape<3>(dim(0, 0, -9), dim(0, 0, -9), dim(0, 0, -9))");
+    ASSERT(s == "shape<3>(dim(0, 0), dim(0, 0), dim(0, 0))");
   }
 
   // Test a few static cases.
   {
     dense_shape<2> sh;
     const std::string s = absl::StrFormat("%v", sh);
-    ASSERT(s == "shape<2>(dim(0, 0, 1), dim(0, 0, -9))");
+    ASSERT(s == "shape<2>(dim(0, 0, 1), dim(0, 0))");
 
     sh.dim<0>().set_extent(10);
     sh.dim<1>().set_min(6);
@@ -140,7 +140,7 @@ TEST(absl_stringify_shape) {
   {
     dense_shape<2> sh;
     const std::string s = absl::StrFormat("%v", sh);
-    ASSERT(s == "shape<2>(dim(0, 0, 1), dim(0, 0, -9))");
+    ASSERT(s == "shape<2>(dim(0, 0, 1), dim(0, 0))");
 
     sh.dim<0>().set_extent(10);
     sh.dim<1>().set_min(6);
@@ -164,7 +164,7 @@ TEST(absl_stringify_shape) {
 
     shape<dense_dim<>, dim<>, dim<>> sh(x, y, z);
     const std::string s = absl::StrFormat("%v", sh);
-    ASSERT(s == "shape<3>(dim(0, 10, 1), dim(67, 5, -10), dim(-11, 103, -9))");
+    ASSERT(s == "shape<3>(dim(0, 10, 1), dim(67, 5, -10), dim(-11, 103))");
 
     // Resolving the stride yields z_stride = 10 * 5 = 50.
     sh.resolve();

--- a/include/array/array.h
+++ b/include/array/array.h
@@ -925,19 +925,19 @@ using enable_if_permutation = std::enable_if_t<sizeof...(Is) == Rank && all(Is <
 template <class DimDst, class DimSrc>
 NDARRAY_HOST_DEVICE void assert_dim_compatible(size_t dim_index, const DimSrc& src) {
   bool compatible = true;
-  if (is_static(DimDst::Min) && is_static(src.min()) && src.min() != DimDst::Min) {
+  if (is_static(DimDst::Min) && src.min() != DimDst::Min) {
     NDARRAY_PRINT_ERR("Error converting dim %zu: expected static min " NDARRAY_INDEX_T_FMT
                       ", got " NDARRAY_INDEX_T_FMT "\n",
         dim_index, DimDst::Min, src.min());
     compatible = false;
   }
-  if (is_static(DimDst::Extent) && is_static(src.extent()) && src.extent() != DimDst::Extent) {
+  if (is_static(DimDst::Extent) && src.extent() != DimDst::Extent) {
     NDARRAY_PRINT_ERR("Error converting dim %zu: expected static extent " NDARRAY_INDEX_T_FMT
                       ", got " NDARRAY_INDEX_T_FMT "\n",
         dim_index, DimDst::Extent, src.extent());
     compatible = false;
   }
-  if (is_static(DimDst::Stride) && is_static(src.stride()) && is_resolved(src.stride()) && src.stride() != DimDst::Stride) {
+  if (is_static(DimDst::Stride) && is_resolved(src.stride()) && src.stride() != DimDst::Stride) {
     NDARRAY_PRINT_ERR("Error converting dim %zu: expected static stride " NDARRAY_INDEX_T_FMT
                       ", got " NDARRAY_INDEX_T_FMT "\n",
         dim_index, DimDst::Stride, src.stride());

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -159,6 +159,7 @@ TEST(array_fill_assign) {
 
   array<int, shape<dim<>, dim<>>> sparse;
   auto sparse_shape = make_shape(dim<>(-2, 5, 2), dim<>(4, 10));
+  sparse_shape.resolve();
   ASSERT_LT(sparse_shape.size(), sparse_shape.flat_extent());
 
   sparse.assign(sparse_shape, 13);

--- a/test/shape.cpp
+++ b/test/shape.cpp
@@ -175,7 +175,7 @@ void check_resolved_strides(shape_of_rank<Rank> shape, const std::vector<index_t
 }
 
 TEST(auto_strides) {
-  check_resolved_strides<1>({{3, 5, dynamic}}, {1});
+  check_resolved_strides<1>({{3, 5, unresolved}}, {1});
   check_resolved_strides<2>({5, 10}, {1, 5});
 
   // Small interleaved.


### PR DESCRIPTION
This makes things a bit more clear, and might make debugging a bit easier (-9 is a not-totally-unreasonable value to see in memory).

The absl changes are a yolo commit, I spent a few minutes trying to install bazel on windows subsystem for linux and ran into issues. It's *probably* right but could easily be broken.