### PR TITLE
Better accounting and fixes of allocator lifetimes

### DIFF
--- a/include/array/array.h
+++ b/include/array/array.h
@@ -2270,7 +2270,8 @@ public:
   /** Copy construct from another array `other`, using copy's allocator. This is
    * a deep copy of the contents of `other`. */
   array(const array& other)
-      : array(alloc_traits::select_on_container_copy_construction(other.get_allocator())) {
+      : alloc_(alloc_traits::select_on_container_copy_construction(other.get_allocator())),
+        buffer_(nullptr), buffer_size_(0), base_(nullptr) {
     assign(other);
   }
 

--- a/test/array_lifetime.cpp
+++ b/test/array_lifetime.cpp
@@ -141,15 +141,9 @@ TEST(array_copy_lifetime) {
 }
 
 template <typename Alloc>
-void test_move_lifetime(bool alloc_movable = true) {
+void test_move_lifetime(const Alloc& alloc, bool alloc_movable = true) {
   {
-    lifetime_array<Alloc> source;
-    if constexpr (std::is_same<Alloc, stateful_movable_custom_alloc>::value) {
-      // A custom allocator that has a different state than the default.
-      source = lifetime_array<Alloc>(lifetime_shape, Alloc(1));
-    } else {
-      source = lifetime_array<Alloc>(lifetime_shape);
-    }
+    lifetime_array<Alloc> source(lifetime_shape, alloc);
     lifetime_counter::reset();
     lifetime_array<Alloc> move(std::move(source));
   }
@@ -176,11 +170,11 @@ void test_move_lifetime(bool alloc_movable = true) {
 }
 
 TEST(array_move_lifetime) {
-  test_move_lifetime<std_alloc>();
-  test_move_lifetime<custom_alloc>();
-  test_move_lifetime<stateful_movable_custom_alloc>();
-  test_move_lifetime<auto_alloc_big>(false);
-  test_move_lifetime<auto_alloc_small>();
+  test_move_lifetime(std_alloc());
+  test_move_lifetime(custom_alloc());
+  test_move_lifetime(stateful_movable_custom_alloc(1));
+  test_move_lifetime(auto_alloc_big(), false);
+  test_move_lifetime(auto_alloc_small());
 }
 
 template <typename Alloc>

--- a/test/array_lifetime.cpp
+++ b/test/array_lifetime.cpp
@@ -204,7 +204,7 @@ TEST(array_move_lifetime) {
   test_move_lifetime(movable_custom_alloc(1));
   test_move_lifetime(auto_alloc_big(), false);
   test_move_lifetime(auto_alloc_small());
-  ASSERT_EQ(movable_custom_alloc::constructs, 8);  // TODO: This seems high. The number below is correct (4 in the test itself, one in the caller).
+  ASSERT_EQ(movable_custom_alloc::constructs, 2 * 4);  // We run tests with movable_custom_alloc twice.
   ASSERT_EQ(immovable_custom_alloc::constructs, 5);
 }
 


### PR DESCRIPTION
- Don't construct an allocator if we're going to move it from another container.
- Fix copies due to use of `select_on_container_copy_construction`.
- Fix warnings about C++17 usage from #88.
- Add a lot more test coverage of allocator lifetimes.