### PR TITLE
Allow assigning unresolved to a static dim stride as a noop.

### DIFF
--- a/include/array/array.h
+++ b/include/array/array.h
@@ -445,14 +445,10 @@ public:
   NDARRAY_INLINE NDARRAY_HOST_DEVICE index_t stride() const { return stride_; }
   NDARRAY_INLINE NDARRAY_HOST_DEVICE void set_stride(index_t stride) {
     if (internal::is_static(Stride_)) {
-      if (internal::is_resolved(stride)) {
-        assert(stride == Stride_);
-      } else {
-        // It is valid to set a static stride to unresolved - it is a noop.
-        return;
-      }
+      assert(internal::is_unresolved(stride) || stride == Stride_);
+    } else {
+      stride_ = stride;
     }
-    stride_ = stride;
   }
 
   /** Offset of the index `at` in this dim in the flat array. */

--- a/test/shape.cpp
+++ b/test/shape.cpp
@@ -421,12 +421,34 @@ TEST(shape_is_in_range_2d) {
   ASSERT(!s.is_in_range(x, -4));
 }
 
-TEST(shape_conversion) {
+TEST(dim_conversion) {
   dense_dim<> x_dense(0, 10);
   dim<> x = x_dense;
 
   assert_dim_eq(x, dim<>(0, 10, 1));
 
+  dim<> y(5, 15);
+  dense_dim<> y_dense(y);
+  assert_dim_eq(y_dense, dense_dim<>(5, 15));
+  dense_dim<> y_dense2 = y;
+  assert_dim_eq(y_dense2, dense_dim<>(5, 15));
+}
+
+TEST(dim_set_stride) {
+  dim<> x(3, 10, 4);
+  x.set_stride(5);
+  ASSERT_EQ(x.stride(), 5);
+
+  dim<dynamic, dynamic, 4> y(100, 120);
+  // set_stride(unresolved) is a valid noop on a static stride.
+  y.set_stride(unresolved);
+  ASSERT_EQ(y.stride(), 4);
+
+  // Uncommenting this will be an assertion failure.
+  // y.set_stride(5);
+}
+
+TEST(shape_conversion) {
   dense_shape<2> static_dense({0, 10}, {1, 5});
   shape_of_rank<2> dense = static_dense;
   ASSERT_EQ(dense, static_dense);
@@ -436,6 +458,10 @@ TEST(shape_conversion) {
 
   dense_shape<2> static_dense2(dense);
   ASSERT_EQ(dense, static_dense2);
+
+  shape_of_rank<2> dense_unresolved({0, 10}, {1, 5});
+  dense_shape<2> static_dense3(dense);
+  ASSERT_EQ(dense, static_dense3);
 
   ASSERT(is_compatible<dense_shape<2>>(dense));
 
@@ -531,7 +557,7 @@ TEST(shape_make_compact) {
   assert_shapes_eq(make_compact(s6), s6_compact);
 }
 
-TEST(shape_fixed_dense) { 
+TEST(shape_fixed_dense) {
   shape<dim<0, 2, 1>, dim<0, 3, 2>, dim<0, 4, 6>, dim<0, 5, 24>> s1;
   fixed_dense_shape<2, 3, 4, 5> s1_fixed;
   assert_shapes_eq(s1, s1_fixed);

--- a/test/shape.cpp
+++ b/test/shape.cpp
@@ -444,7 +444,7 @@ TEST(dim_set_stride) {
   y.set_stride(unresolved);
   ASSERT_EQ(y.stride(), 4);
 
-  // Uncommenting this will be an assertion failure.
+  // Uncommenting this will cause an assertion failure.
   // y.set_stride(5);
 }
 


### PR DESCRIPTION
- When setting a static stride to any other value, asserts that the value equals the static value.
- This allows shapes where some strides are static to be constructed or assigned to unresolved shapes.