### PR TITLE
Adjusts stride calculation for single-row interleaved or single-plane planar images.

### DIFF
--- a/include/array/array.h
+++ b/include/array/array.h
@@ -796,9 +796,12 @@ NDARRAY_HOST_DEVICE bool is_stride_ok(index_t stride, index_t extent, const Dim&
     return true;
   }
   if (extent == 1 && abs(stride) == abs(dim.stride()) && dim.extent() > 1) {
-    // Special-cases "extent == 1" to avoid unexpectedly giving a stride of 1 for
-    // outer dimensions; e.g. the y-stride for single-row interleaved images, or
-    // the plane-stride for single-plane Planar images.
+    // If a dimension is extent 1, avoid giving this dimension the same stride
+    // as another dimension with extent greater than 1. This doesn't affect the
+    // results of most programs (because the stride only ever multiplied with
+    // zero), but it makes the strides less objectionable to asserts in some
+    // other libraries that make extra assumptions about images, and may be
+    // easier to understand.
     return false;
   }
   if (dim.extent() * abs(dim.stride()) <= stride) {

--- a/include/array/array.h
+++ b/include/array/array.h
@@ -795,6 +795,12 @@ NDARRAY_HOST_DEVICE bool is_stride_ok(index_t stride, index_t extent, const Dim&
     // resolving the current dim first.
     return true;
   }
+  if (extent == 1 && abs(stride) == abs(dim.stride()) && dim.extent() > 1) {
+    // Special-cases "extent == 1" to avoid unexpectedly giving a stride of 1 for
+    // outer dimensions; e.g. the y-stride for single-row interleaved images, or
+    // the plane-stride for single-plane Planar images.
+    return false;
+  }
   if (dim.extent() * abs(dim.stride()) <= stride) {
     // The dim is completely inside the proposed stride.
     return true;

--- a/test/shape.cpp
+++ b/test/shape.cpp
@@ -178,10 +178,11 @@ TEST(auto_strides) {
   check_resolved_strides<1>({{3, 5, unresolved}}, {1});
   check_resolved_strides<2>({5, 10}, {1, 5});
 
-  // Small interleaved.
-  // TODO: This test would be nice to enable, but the automatic strides are too clever.
-  // x is given a stride of 1, which is safe and correct, but annoying.
-  // check_resolved_strides<3>({1, 1, {0, 2, 1}}, {2, 2, 1});
+  // Stride one dimensions mixed in with extent 1 dimensions.
+  check_resolved_strides<3>({1, 1, {0, 2, 1}}, {2, 2, 1});
+  check_resolved_strides<3>({1, {0, 2, 1}, 1}, {2, 1, 2});
+  check_resolved_strides<3>({1, 10, {0, 2, 1}}, {2, 2, 1});
+  check_resolved_strides<3>({5, {0, 2, 1}, 1}, {2, 1, 10});
 
   // Interleaved with row stride.
   check_resolved_strides<3>({5, {0, 4, 20}, {0, 3, 1}}, {3, 20, 1});


### PR DESCRIPTION
Fix for Issue [#91](https://github.com/dsharlet/array/issues/91). Adjusts automatic stride calculation to improve an edge case where single-row images were getting assigned a y-stride of 1, rather than the number of row elements. (Similarly for plane-stride of planar images with a single plane.)