### PR TITLE
Use non-resolving version of array_ref::array_ref where appropriate

### DIFF
--- a/include/array/array.h
+++ b/include/array/array.h
@@ -2165,7 +2165,7 @@ public:
 
   /** Allow conversion from array_ref<T> to const_array_ref<T>. */
   NDARRAY_HOST_DEVICE const const_array_ref<T, Shape> cref() const {
-    return const_array_ref<T, Shape>(base_, shape_);
+    return const_array_ref<T, Shape>(base_, shape_, std::false_type{});
   }
   NDARRAY_HOST_DEVICE operator const_array_ref<T, Shape>() const { return cref(); }
 
@@ -2662,8 +2662,10 @@ public:
   }
 
   /** Make an array_ref referring to the data in this array. */
-  array_ref<T, Shape> ref() { return array_ref<T, Shape>(base_, shape_); }
-  const_array_ref<T, Shape> cref() const { return const_array_ref<T, Shape>(base_, shape_); }
+  array_ref<T, Shape> ref() { return array_ref<T, Shape>(base_, shape_, std::false_type{}); }
+  const_array_ref<T, Shape> cref() const {
+    return const_array_ref<T, Shape>(base_, shape_, std::false_type{});
+  }
   const_array_ref<T, Shape> ref() const { return cref(); }
   operator array_ref<T, Shape>() { return ref(); }
   operator const_array_ref<T, Shape>() const { return cref(); }
@@ -2939,7 +2941,7 @@ bool equal(const array<TA, ShapeA, AllocA>& a, const array<TB, ShapeB, AllocB>& 
  * `NewShape`. The new shape is copy constructed from `a.shape()`. */
 template <class NewShape, class T, class OldShape>
 NDARRAY_HOST_DEVICE array_ref<T, NewShape> convert_shape(const array_ref<T, OldShape>& a) {
-  return array_ref<T, NewShape>(a.base(), convert_shape<NewShape>(a.shape()));
+  return array_ref<T, NewShape>(a.base(), convert_shape<NewShape>(a.shape()), std::false_type{});
 }
 template <class NewShape, class T, class OldShape, class Allocator>
 array_ref<T, NewShape> convert_shape(array<T, OldShape, Allocator>& a) {
@@ -2954,7 +2956,7 @@ const_array_ref<T, NewShape> convert_shape(const array<T, OldShape, Allocator>& 
  * `U`. `sizeof(T)` must be equal to `sizeof(U)`. */
 template <class U, class T, class Shape, class = std::enable_if_t<sizeof(T) == sizeof(U)>>
 NDARRAY_HOST_DEVICE array_ref<U, Shape> reinterpret(const array_ref<T, Shape>& a) {
-  return array_ref<U, Shape>(reinterpret_cast<U*>(a.base()), a.shape());
+  return array_ref<U, Shape>(reinterpret_cast<U*>(a.base()), a.shape(), std::false_type{});
 }
 template <class U, class T, class Shape, class Alloc,
     class = std::enable_if_t<sizeof(T) == sizeof(U)>>
@@ -2971,7 +2973,7 @@ const_array_ref<U, Shape> reinterpret(const array<T, Shape, Alloc>& a) {
  * type `U` using `const_cast`. */
 template <class U, class T, class Shape>
 array_ref<U, Shape> reinterpret_const(const const_array_ref<T, Shape>& a) {
-  return array_ref<U, Shape>(const_cast<U*>(a.base()), a.shape());
+  return array_ref<U, Shape>(const_cast<U*>(a.base()), a.shape(), std::false_type{});
 }
 
 /** Reinterpret the shape of the array or array_ref `a` to be a new shape

--- a/include/array/array.h
+++ b/include/array/array.h
@@ -1965,9 +1965,11 @@ NDARRAY_HOST_DEVICE array_ref<T, Shape> make_array_ref(T* base, const Shape& sha
 
 namespace internal {
 
+struct no_resolve {};
+
 template <class T, class Shape>
 NDARRAY_HOST_DEVICE array_ref<T, Shape> make_array_ref_no_resolve(T* base, const Shape& shape) {
-  return {base, shape, std::false_type()};
+  return {base, shape, no_resolve{}};
 }
 
 template <class T, class Shape, class... Args>
@@ -2032,7 +2034,7 @@ public:
     shape_.resolve();
   }
 
-  NDARRAY_HOST_DEVICE array_ref(pointer base, const Shape& shape, std::false_type /*resolve*/)
+  NDARRAY_HOST_DEVICE array_ref(pointer base, const Shape& shape, internal::no_resolve)
       : base_(base), shape_(shape) {}
 
   /** Shallow copy or assign an array_ref. */
@@ -2044,7 +2046,7 @@ public:
   /** Shallow copy or assign an array_ref with a different shape type. */
   template <class OtherShape, class = enable_if_shape_compatible<OtherShape>>
   NDARRAY_HOST_DEVICE array_ref(const array_ref<T, OtherShape>& other)
-      : array_ref(other.base(), other.shape(), std::false_type()) {}
+      : array_ref(other.base(), other.shape(), internal::no_resolve{}) {}
   template <class OtherShape, class = enable_if_shape_compatible<OtherShape>>
   NDARRAY_HOST_DEVICE array_ref& operator=(const array_ref<T, OtherShape>& other) {
     base_ = other.base();
@@ -2165,7 +2167,7 @@ public:
 
   /** Allow conversion from array_ref<T> to const_array_ref<T>. */
   NDARRAY_HOST_DEVICE const const_array_ref<T, Shape> cref() const {
-    return const_array_ref<T, Shape>(base_, shape_, std::false_type{});
+    return const_array_ref<T, Shape>(base_, shape_, internal::no_resolve{});
   }
   NDARRAY_HOST_DEVICE operator const_array_ref<T, Shape>() const { return cref(); }
 
@@ -2662,9 +2664,9 @@ public:
   }
 
   /** Make an array_ref referring to the data in this array. */
-  array_ref<T, Shape> ref() { return array_ref<T, Shape>(base_, shape_, std::false_type{}); }
+  array_ref<T, Shape> ref() { return array_ref<T, Shape>(base_, shape_, internal::no_resolve{}); }
   const_array_ref<T, Shape> cref() const {
-    return const_array_ref<T, Shape>(base_, shape_, std::false_type{});
+    return const_array_ref<T, Shape>(base_, shape_, internal::no_resolve{});
   }
   const_array_ref<T, Shape> ref() const { return cref(); }
   operator array_ref<T, Shape>() { return ref(); }
@@ -2941,7 +2943,7 @@ bool equal(const array<TA, ShapeA, AllocA>& a, const array<TB, ShapeB, AllocB>& 
  * `NewShape`. The new shape is copy constructed from `a.shape()`. */
 template <class NewShape, class T, class OldShape>
 NDARRAY_HOST_DEVICE array_ref<T, NewShape> convert_shape(const array_ref<T, OldShape>& a) {
-  return array_ref<T, NewShape>(a.base(), convert_shape<NewShape>(a.shape()), std::false_type{});
+  return array_ref<T, NewShape>(a.base(), convert_shape<NewShape>(a.shape()), internal::no_resolve{});
 }
 template <class NewShape, class T, class OldShape, class Allocator>
 array_ref<T, NewShape> convert_shape(array<T, OldShape, Allocator>& a) {
@@ -2956,7 +2958,7 @@ const_array_ref<T, NewShape> convert_shape(const array<T, OldShape, Allocator>& 
  * `U`. `sizeof(T)` must be equal to `sizeof(U)`. */
 template <class U, class T, class Shape, class = std::enable_if_t<sizeof(T) == sizeof(U)>>
 NDARRAY_HOST_DEVICE array_ref<U, Shape> reinterpret(const array_ref<T, Shape>& a) {
-  return array_ref<U, Shape>(reinterpret_cast<U*>(a.base()), a.shape(), std::false_type{});
+  return array_ref<U, Shape>(reinterpret_cast<U*>(a.base()), a.shape(), internal::no_resolve{});
 }
 template <class U, class T, class Shape, class Alloc,
     class = std::enable_if_t<sizeof(T) == sizeof(U)>>
@@ -2973,7 +2975,7 @@ const_array_ref<U, Shape> reinterpret(const array<T, Shape, Alloc>& a) {
  * type `U` using `const_cast`. */
 template <class U, class T, class Shape>
 array_ref<U, Shape> reinterpret_const(const const_array_ref<T, Shape>& a) {
-  return array_ref<U, Shape>(const_cast<U*>(a.base()), a.shape(), std::false_type{});
+  return array_ref<U, Shape>(const_cast<U*>(a.base()), a.shape(), internal::no_resolve{});
 }
 
 /** Reinterpret the shape of the array or array_ref `a` to be a new shape


### PR DESCRIPTION
This fixes an issue I noticed with @fbleibel-g where calls to `resolve_unknown_strides` was getting called in an example where I didn't expect it. This modifies some uses of `array_ref::array_ref` to use the non-resolving version of the constructor when we're using a shape that should have already been resolved.

This is a bit of a dangerous change, it's possible that some wonky usage of the array library could result in unresolved shapes getting resolved via these calls, but IMO that would be a bug if that were the case, that should be fixed elsewhere.